### PR TITLE
refactor: SKILL.md 슬림화 — 아키텍처 강의 분리 + Phase 4 간소화

### DIFF
--- a/skills/context-engineering/SKILL.md
+++ b/skills/context-engineering/SKILL.md
@@ -253,56 +253,10 @@ WHAT/WHY/HOW 3섹션 구조:
 
 ### Step 3-3. 패키지/모듈 구조
 
-언어보다 **설계 원칙**을 먼저 정의한다. 폴더명은 원칙에서 파생된다.
+Ports & Adapters + DDD 기반으로 레이어를 설계한다.
+의존 방향: `진입점 → 애플리케이션 → 도메인 ← 인프라` (역방향 금지)
 
-**왜 레이어를 나누는가 (SoC + Cohesion/Coupling)**
-
-- **High Cohesion**: 같은 이유로 변경되는 코드는 같은 모듈에
-- **Low Coupling**: 다른 이유로 변경되는 코드는 다른 모듈로 분리
-- **SoC**: 하나의 모듈은 하나의 관심사(도메인 규칙 / 기술 세부사항 / 입출력 변환)만
-
-> SOLID는 이 원칙의 OOP 구체화. DDD는 도메인 관심사를 비즈니스 언어로 명시.
-
-**레이어 설계 (Ports & Adapters + DDD)**
-
-| 레이어 | Ports & Adapters | 책임 (SRP) | 의존 규칙 (DIP) | DDD 개념 |
-|--------|-----------------|-----------|----------------|---------|
-| 도메인 | — (순수 도메인) | 비즈니스 규칙·불변식 | 외부 의존 없음 (순수) | Entity, Value Object, Aggregate, Domain Service, Repository 포트(인터페이스) |
-| 애플리케이션 | — (Use Case) | 유스케이스 조율 (CQS 적용) | 도메인만 | Application Service, Command Handler, Query Handler |
-| 인프라 | Driven Adapter (Secondary) | 외부 시스템 구현체 | 도메인 포트 역전(DIP) | Repository 구현, External API Adapter |
-| 진입점 | Driving Adapter (Primary) | 입력 수신·변환 | 애플리케이션만 | HTTP Controller, Message Consumer |
-| 설정 | — | 의존성 조립 | 전 레이어 | DI 설정, 환경 변수 바인딩 |
-
-의존 방향: `진입점(Primary) → 애플리케이션 → 도메인 ← 인프라(Secondary)` (역방향 금지)
-
-**책임 할당 — GRASP Information Expert**
-
-책임은 그 정보를 가진 객체에 둔다:
-- 주문 총액 계산 → `Order` (항목 정보를 가진 쪽이 책임 — OrderService 아님)
-- 할인 정책 적용 → `DiscountPolicy` (정책 규칙을 아는 쪽이 책임 — Order 아님)
-- 재고 확인 → `Inventory` (재고 수량을 가진 쪽이 책임)
-
-**CQS — Application Service 설계 기준**
-
-Application Service의 메서드는 둘 중 하나만:
-- **Command**: 상태 변경 + 반환값 없음 — `createOrder()`, `cancelPayment()`
-- **Query**: 상태 변경 없음 + 값 반환 — `getOrderById()`, `listPendingOrders()`
-
-**OCP 적용 기준**
-
-- 비즈니스 규칙 변경 → 도메인 레이어만 수정
-- 외부 API 교체 → 인프라(Secondary Adapter)만 수정 (도메인·애플리케이션 무변경)
-- 새 유스케이스 추가 → 애플리케이션 레이어 확장 (기존 코드 닫힘)
-
-**언어별 폴더명 대응**
-
-| 레이어 | Java | Node.js | Python | Go |
-|--------|------|---------|--------|----|
-| 도메인 | `domain/` | `domain/` | `domain/` | `internal/domain/` |
-| 애플리케이션 | `application/` | `services/` | `services/` | `internal/service/` |
-| 인프라 | `infrastructure/` | `repositories/` | `infra/` | `internal/repository/` |
-| 진입점 | `adapter/in/` | `routes/` | `api/` | `internal/handler/` |
-| 설정 | `config/` | `config/` | `core/` | `internal/config/` |
+원칙·레이어 정의·언어별 폴더명 → [references/architecture-principles.md](references/architecture-principles.md)
 
 ### Step 3-4. WBS
 
@@ -331,24 +285,10 @@ Application Service의 메서드는 둘 중 하나만:
 
 **진입 기준**: Phase 3 해당 WBS 항목의 FR-*, D-* 확인 완료
 
-1. 스켈레톤 생성 (패키지 구조, 빈 클래스/모듈)
-2. 핵심 도메인 객체 구현
-3. 어댑터 구현
-4. 테스트 작성 + 통과 확인
-5. 발견 사항을 피드백 루프에 따라 해당 단계 문서에 반영
-
 **완료 기준**: 아래 체크리스트 전부 통과 시만 다음 단계로 이동
 
-```bash
-# 컴파일
-{BUILD_CMD}
-
-# 테스트
-{TEST_CMD}
-```
-
-- [ ] 빌드 성공 (컴파일 에러 없음)
-- [ ] 테스트 통과 (신규 + 기존 회귀 없음)
+- [ ] `{BUILD_CMD}` 성공
+- [ ] `{TEST_CMD}` 통과 (신규 + 기존 회귀 없음)
 - [ ] Phase 3 설계 결정(D-*) 준수
 - [ ] 발견 사항 해당 단계 문서에 반영 완료
 
@@ -383,3 +323,4 @@ Application Service의 메서드는 둘 중 하나만:
 - [Knowledge Base 템플릿](references/knowledge-base-template.md)
 - [CLAUDE.md 정책 템플릿](references/claude-md-policy-template.md)
 - [구현 Spec 템플릿](references/spec-template.md)
+- [아키텍처 원칙](references/architecture-principles.md)

--- a/skills/context-engineering/references/architecture-principles.md
+++ b/skills/context-engineering/references/architecture-principles.md
@@ -1,0 +1,52 @@
+# 아키텍처 원칙
+
+Phase 3 패키지/모듈 구조 설계 시 참조한다.
+
+## 왜 레이어를 나누는가 (SoC + Cohesion/Coupling)
+
+- **High Cohesion**: 같은 이유로 변경되는 코드는 같은 모듈에
+- **Low Coupling**: 다른 이유로 변경되는 코드는 다른 모듈로 분리
+- **SoC**: 하나의 모듈은 하나의 관심사(도메인 규칙 / 기술 세부사항 / 입출력 변환)만
+
+> SOLID는 이 원칙의 OOP 구체화. DDD는 도메인 관심사를 비즈니스 언어로 명시.
+
+## 레이어 설계 (Ports & Adapters + DDD)
+
+| 레이어 | Ports & Adapters | 책임 (SRP) | 의존 규칙 (DIP) | DDD 개념 |
+|--------|-----------------|-----------|----------------|---------|
+| 도메인 | — (순수 도메인) | 비즈니스 규칙·불변식 | 외부 의존 없음 (순수) | Entity, Value Object, Aggregate, Domain Service, Repository 포트(인터페이스) |
+| 애플리케이션 | — (Use Case) | 유스케이스 조율 (CQS 적용) | 도메인만 | Application Service, Command Handler, Query Handler |
+| 인프라 | Driven Adapter (Secondary) | 외부 시스템 구현체 | 도메인 포트 역전(DIP) | Repository 구현, External API Adapter |
+| 진입점 | Driving Adapter (Primary) | 입력 수신·변환 | 애플리케이션만 | HTTP Controller, Message Consumer |
+| 설정 | — | 의존성 조립 | 전 레이어 | DI 설정, 환경 변수 바인딩 |
+
+의존 방향: `진입점(Primary) → 애플리케이션 → 도메인 ← 인프라(Secondary)` (역방향 금지)
+
+## 책임 할당 — GRASP Information Expert
+
+책임은 그 정보를 가진 객체에 둔다:
+- 주문 총액 계산 → `Order` (항목 정보를 가진 쪽이 책임 — OrderService 아님)
+- 할인 정책 적용 → `DiscountPolicy` (정책 규칙을 아는 쪽이 책임 — Order 아님)
+- 재고 확인 → `Inventory` (재고 수량을 가진 쪽이 책임)
+
+## CQS — Application Service 설계 기준
+
+Application Service의 메서드는 둘 중 하나만:
+- **Command**: 상태 변경 + 반환값 없음 — `createOrder()`, `cancelPayment()`
+- **Query**: 상태 변경 없음 + 값 반환 — `getOrderById()`, `listPendingOrders()`
+
+## OCP 적용 기준
+
+- 비즈니스 규칙 변경 → 도메인 레이어만 수정
+- 외부 API 교체 → 인프라(Secondary Adapter)만 수정 (도메인·애플리케이션 무변경)
+- 새 유스케이스 추가 → 애플리케이션 레이어 확장 (기존 코드 닫힘)
+
+## 언어별 폴더명 대응
+
+| 레이어 | Java | Node.js | Python | Go |
+|--------|------|---------|--------|----|
+| 도메인 | `domain/` | `domain/` | `domain/` | `internal/domain/` |
+| 애플리케이션 | `application/` | `services/` | `services/` | `internal/service/` |
+| 인프라 | `infrastructure/` | `repositories/` | `infra/` | `internal/repository/` |
+| 진입점 | `adapter/in/` | `routes/` | `api/` | `internal/handler/` |
+| 설정 | `config/` | `config/` | `core/` | `internal/config/` |


### PR DESCRIPTION
## 변경 내용

### SKILL.md (386줄 → 326줄)
- Phase 3 아키텍처 원칙 설명(SOLID·DDD·GRASP·CQS·OCP·언어별 폴더명) → `references/architecture-principles.md`로 분리
- Phase 3-3을 3줄 + 링크로 대체
- Phase 4 구현 단계(1~5) 제거 — 완료 기준 체크리스트만 유지

### 신규: `references/architecture-principles.md`
- 분리된 아키텍처 원칙 전문

Closes #11