### PR TITLE
feat: Phase 1~3 반복 구체화 루프 + Readiness Gate 추가

### DIFF
--- a/docs/context-engineering-cycle.html
+++ b/docs/context-engineering-cycle.html
@@ -243,6 +243,10 @@
         <div class="legend-line dashed"></div>
         <span>피드백 루프 (Spec 갱신)</span>
       </div>
+      <div class="legend-item">
+        <div class="legend-line dashed" style="background: linear-gradient(90deg, #f59e0b 60%, transparent 60%); background-size: 10px 2px;"></div>
+        <span>재순환 (Readiness Gate 미충족)</span>
+      </div>
     </div>
 
     <section class="cards-section" data-reveal>
@@ -366,8 +370,8 @@
         id: 'phase3', label: 'Phase 3', name: 'Spec',
         angle: 126, color: '#f59e0b',
         icon: 'file',
-        steps: ['기능 요구사항 (FR-*) — 수용 기준 포함', '설계 결정 (D-*) — 대안/선택/근거', '패키지/모듈 구조 확정', 'WBS 작성 — 의존성, 예상 산출물', '구현 순서 결정'],
-        gate: 'Phase 3 완료 — spec/ 초안 검토 후 Phase 4 진행할까요?'
+        steps: ['기능 요구사항 (FR-*) — 수용 기준 포함', '설계 결정 (D-*) — 대안/선택/근거', '패키지/모듈 구조 확정', 'WBS 작성 — 의존성, 예상 산출물', 'Readiness Gate — 5개 기준 충족 시 Phase 4 진입'],
+        gate: '미충족 항목 있으면 Phase 1~3 재순환. 모두 충족 시 Phase 4 진입.'
       },
       {
         id: 'phase4', label: 'Phase 4', name: 'Implementation',
@@ -485,6 +489,7 @@
       var surfaceColor = isDark ? '#141414' : '#FFFFFF';
       var guideColor  = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.07)';
       var fbColor     = isDark ? 'rgba(255,255,255,0.22)' : 'rgba(0,0,0,0.22)';
+      var refineColor = isDark ? '#f59e0b' : '#d97706';
 
       /* --- DEFS --- */
       var defs = makeSVGEl('defs', {});
@@ -506,6 +511,14 @@
       });
       var pfb = makeSVGEl('polygon', { points: '0 0, 8 3, 0 6', fill: fbColor });
       mfb.appendChild(pfb); defs.appendChild(mfb);
+
+      // Refinement loop arrow marker
+      var mref = makeSVGEl('marker', {
+        id: 'arr-refine', markerWidth: '8', markerHeight: '6',
+        refX: '7', refY: '3', orient: 'auto'
+      });
+      var pref = makeSVGEl('polygon', { points: '0 0, 8 3, 0 6', fill: refineColor });
+      mref.appendChild(pref); defs.appendChild(mref);
 
       // Glow filters
       PHASES.forEach(function(p) {
@@ -626,6 +639,50 @@
           'font-family': 'Noto Sans KR, Inter, sans-serif', 'font-weight': '600'
         });
         lbl.textContent = 'Spec 갱신';
+        svg.appendChild(lbl);
+      })();
+
+      /* --- REFINEMENT LOOP ARROW: Phase 3 → Phase 1 (inward, dashed, amber) --- */
+      (function() {
+        var f = PHASES[3], t = PHASES[1]; // Phase 3 → Phase 1
+        var dx = t.cx - f.cx, dy = t.cy - f.cy;
+        var dist = Math.sqrt(dx*dx + dy*dy);
+        var nx = dx/dist, ny = dy/dist;
+
+        var sx = f.cx + nx*(NR+3), sy = f.cy + ny*(NR+3);
+        var ex = t.cx - nx*(NR+12), ey = t.cy - ny*(NR+12);
+
+        // Push control point toward center (inward)
+        var mx = (sx+ex)/2, my = (sy+ey)/2;
+        var dcx = CX - mx, dcy = CY - my;
+        var dcd = Math.sqrt(dcx*dcx + dcy*dcy);
+        var cp_x = mx + (dcx/dcd)*130;
+        var cp_y = my + (dcy/dcd)*130;
+
+        var path = makeSVGEl('path', {
+          d: 'M '+sx+' '+sy+' Q '+cp_x+' '+cp_y+' '+ex+' '+ey,
+          fill: 'none', stroke: refineColor, 'stroke-width': '1.5',
+          'stroke-dasharray': '5,4', 'stroke-linecap': 'round',
+          'marker-end': 'url(#arr-refine)'
+        });
+        svg.appendChild(path);
+
+        // Label near bezier midpoint
+        var lx = 0.25*sx + 0.5*cp_x + 0.25*ex;
+        var ly = 0.25*sy + 0.5*cp_y + 0.25*ey;
+
+        var bg = makeSVGEl('rect', {
+          x: lx-32, y: ly-10, width: '64', height: '20', rx: '6',
+          fill: surfaceColor, stroke: refineColor, 'stroke-width': '1'
+        });
+        svg.appendChild(bg);
+
+        var lbl = makeSVGEl('text', {
+          x: lx, y: ly, 'text-anchor': 'middle', 'dominant-baseline': 'middle',
+          fill: refineColor, 'font-size': '11',
+          'font-family': 'Noto Sans KR, Inter, sans-serif', 'font-weight': '600'
+        });
+        lbl.textContent = '재순환';
         svg.appendChild(lbl);
       })();
 

--- a/skills/context-engineering/SKILL.md
+++ b/skills/context-engineering/SKILL.md
@@ -16,12 +16,15 @@ AI 도구로 복잡한 서비스를 개발할 때 **"무엇을 알고, 어떻게
 ```
 Step 0: Context Gathering  ←  요구사항 탐색 + 파라미터 수집
   ↓  [HARD-GATE: 요구사항 확인 완료 시만 진입]
-Phase 1: Knowledge Base  →  확인
-  ↓
-Phase 2: Policy (CLAUDE.md)  →  확인
-  ↓
-Phase 3: Spec (구현 명세)  →  확인
-  ↓
+┌──────────────────────────────────────────┐
+│  Phase 1: Knowledge Base                 │
+│    ↓                                     │
+│  Phase 2: Policy (CLAUDE.md)             │
+│    ↓                                     │
+│  Phase 3: Spec  →  [Readiness Gate]      │
+│    ↑_________________↓ 미충족 시 재순환  │
+└──────────────────────────────────────────┘
+  ↓  [HARD-GATE: 계획 준비 완료]
 Phase 4: Implementation
 ```
 
@@ -268,7 +271,21 @@ Ports & Adapters + DDD 기반으로 레이어를 설계한다.
 
 **산출물**: `{OUTPUT_PATH}/spec/`
 
-> **게이트**: "Phase 3 완료 — `spec/` 초안을 저장했습니다. 검토 후 Phase 4 진행할까요?"
+### Step 3-6. Readiness Gate (반복 여부 판단)
+
+아래 기준을 모두 충족해야 Phase 4로 진행한다.
+
+| 기준 | 미충족 시 돌아갈 Phase |
+|------|----------------------|
+| 모든 FR-*에 검증 가능한 수용 기준이 있는가? | Phase 3 |
+| 설계 결정(D-*)에 대안과 근거가 있는가? | Phase 3 |
+| 도메인 용어 미확정 항목이 없는가? | Phase 1 |
+| CLAUDE.md가 실제 제약을 반영하는가? | Phase 2 |
+| WBS 첫 번째 작업을 지금 바로 시작할 수 있는가? | Phase 3 |
+
+하나라도 미충족이면 해당 Phase로 돌아가 보강 후 Phase 3까지 재순환한다.
+
+> **HARD-GATE**: 모두 충족 시 "계획 준비 완료 — Phase 4로 진행합니다." 출력 후 Phase 4 진입.
 
 ---
 


### PR DESCRIPTION
## 변경 내용

### SKILL.md
- 상단 흐름 다이어그램을 선형 → 루프 구조로 변경
- Phase 3 끝에 `Step 3-6. Readiness Gate` 추가 — 5개 기준 미충족 시 Phase 1~3 재순환

### HTML 다이어그램
- Phase 3 → Phase 1 재순환 화살표(amber 점선) 추가
- Phase 3 카드 steps/gate 업데이트
- 범례에 재순환 항목 추가

Closes #19