### PR TITLE
docs: README plugin list 출력 형식 수정 + CLAUDE.md 서브스킬 구조 반영

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,12 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 소스 코드 없음. **순수 마크다운** Claude Code 플러그인:
 - `plugin.json` — 플러그인 메타데이터
-- `skills/context-engineering/SKILL.md` — 스킬 정의 (워크플로우 핵심)
+- `skills/context-engineering/SKILL.md` — 전체 워크플로우 스킬 (Step 0 → Phase 4)
 - `skills/context-engineering/references/` — 각 Phase 산출물 템플릿
+- `skills/gather/SKILL.md` — 서브스킬: Step 0 + Phase 1 (KB) + Phase 2 (CLAUDE.md)
+- `skills/spec/SKILL.md` — 서브스킬: Phase 3 (PRD + SPEC)
+- `skills/valid/SKILL.md` — 서브스킬: Readiness Gate 검증
+- `skills/impl/SKILL.md` — 서브스킬: Phase 4 (구현)
 
 ## 스킬 수정 시 주의사항
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ claude plugin install context-engineering
 설치 확인:
 ```bash
 claude plugin list
-# context-engineering@context-engineering  Version: 1.0.0  Status: ✔ enabled
+#   ❯ context-engineering@context-engineering
+#     Version: 1.0.0
+#     Scope: user
+#     Status: ✔ enabled
 ```
 
 로컬 디렉토리에서 바로 사용할 때:


### PR DESCRIPTION
Closes #71

## 변경 사항

### README.md
- `claude plugin list` 출력 예시를 실제 CLI 출력 형식에 맞게 수정 (멀티라인 + Scope 필드)

### CLAUDE.md
- 서브스킬 4종 (`gather`, `spec`, `valid`, `impl`) 파일 경로 및 역할 추가