### PR TITLE
feat: 다이어그램에 서브스킬 명령어 표시 + Sub-skills 섹션 추가

### DIFF
--- a/docs/context-engineering-cycle.html
+++ b/docs/context-engineering-cycle.html
@@ -186,6 +186,44 @@
     .scenario-title { font-size: 0.88rem; font-weight: 600; margin-bottom: 4px; }
     .scenario-desc { font-size: 0.78rem; color: var(--text-secondary); }
 
+    /* === SUB-SKILLS === */
+    .subskill-section {
+      max-width: 960px; margin: 48px auto 0; padding: 0 24px;
+    }
+    .subskill-section > h2 { margin-bottom: 20px; color: var(--text-secondary); font-weight: 500; }
+    .subskill-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      gap: 12px;
+    }
+    .subskill-card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-left: 3px solid transparent;
+      border-radius: 10px; padding: 16px;
+      transition: box-shadow 0.2s;
+    }
+    .subskill-card:hover { box-shadow: 0 4px 14px rgba(0,0,0,0.09); }
+    .subskill-cmd {
+      font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+      font-size: 0.78rem; font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .subskill-covers {
+      font-size: 0.72rem; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.06em;
+      opacity: 0.7; margin-bottom: 6px;
+    }
+    .subskill-desc { font-size: 0.78rem; color: var(--text-secondary); }
+
+    /* Sub-skill badge on phase cards */
+    .subskill-badge {
+      display: inline-block;
+      font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+      font-size: 0.69rem; font-weight: 600;
+      padding: 3px 8px; border-radius: 6px;
+      margin-top: 12px; margin-bottom: 2px;
+      border: 1px solid transparent;
+    }
+
     /* SVG node hover */
     .svg-node { cursor: pointer; }
     .svg-node .glow-ring { animation: nodePulse 3s ease-in-out infinite; }
@@ -252,6 +290,11 @@
     <section class="cards-section" data-reveal>
       <h2>단계별 작업 내용</h2>
       <div class="cards-grid" id="phaseCardsGrid"></div>
+    </section>
+
+    <section class="subskill-section" data-reveal>
+      <h2>Sub-skills — Phase별 직접 진입</h2>
+      <div class="subskill-grid" id="subskillGrid"></div>
     </section>
 
     <section class="scenario-section" data-reveal>
@@ -344,11 +387,39 @@
     var SVG_NS = 'http://www.w3.org/2000/svg';
     var CX = 490, CY = 410, ORBIT = 255, NR = 58;
 
+    var SUBSKILLS = [
+      {
+        cmd: '/context-engineering:gather',
+        covers: 'Step 0 · Phase 1 · Phase 2',
+        color: '#6366f1',
+        desc: '새 프로젝트 시작 또는 KB·CLAUDE.md 재작업·갱신. 요구사항 탐색 → Knowledge Base → Policy(CLAUDE.md) 작성.'
+      },
+      {
+        cmd: '/context-engineering:spec',
+        covers: 'Phase 3',
+        color: '#f59e0b',
+        desc: 'PRD(제품 요구사항) + SPEC(기술 명세) 작성. 기존 문서가 있으면 자동 탐지해 갱신.'
+      },
+      {
+        cmd: '/context-engineering:valid',
+        covers: 'Readiness Gate',
+        color: '#8b5cf6',
+        desc: 'Phase 4 진입 전 체크포인트. AI가 현재 상태 요약 → 사용자가 통과 여부 결정.'
+      },
+      {
+        cmd: '/context-engineering:impl',
+        covers: 'Phase 4',
+        color: '#10b981',
+        desc: 'SPEC 구현 계획 순서대로 구현. 완료 기준 검증 + 피드백 루프 반복.'
+      }
+    ];
+
     var PHASES = [
       {
         id: 'step0', label: 'Step 0', name: 'Context Gathering',
         angle: -90, color: '#6366f1',
         icon: 'gather',
+        subskill: '/context-engineering:gather',
         steps: [
           '요구사항 탐색 — 무엇·왜·제약 (질문 1개씩, 답변 후 다음)',
           '요구사항 요약 → 사용자 확인 (HARD-GATE)',
@@ -362,6 +433,7 @@
         id: 'phase1', label: 'Phase 1', name: 'Knowledge Base',
         angle: -18, color: '#3b82f6',
         icon: 'book',
+        subskill: '/context-engineering:gather',
         steps: [
           'Context Assessment — A/B/C/D 판별 후 사용자 확인 필수',
           'Source Scan — A: 대화 기반 / B: 스펙 탐색 / C: 코드 스캔 / D: B+C 병렬',
@@ -375,6 +447,7 @@
         id: 'phase2', label: 'Phase 2', name: 'Policy (CLAUDE.md)',
         angle: 54, color: '#8b5cf6',
         icon: 'shield',
+        subskill: '/context-engineering:gather',
         steps: [
           'CLAUDE.md 레벨 결정 (프로젝트/모듈)',
           '아키텍처 — 복잡한 서비스: Hexagonal+DDD / 단순 프로젝트: 자유 기술',
@@ -388,6 +461,7 @@
         id: 'phase3', label: 'Phase 3', name: 'Spec',
         angle: 126, color: '#f59e0b',
         icon: 'file',
+        subskill: '/context-engineering:spec',
         steps: [
           'PRD — 기능 요구사항 + 검증 가능한 성공 기준',
           'SPEC — 아키텍처 결정 (대안/선택/근거)',
@@ -401,6 +475,7 @@
         id: 'phase4', label: 'Phase 4', name: 'Implementation',
         angle: 198, color: '#10b981',
         icon: 'code',
+        subskill: '/context-engineering:impl',
         steps: [
           'SPEC 구현 계획 순서대로 구현',
           '빌드 + 테스트 통과 확인',
@@ -849,6 +924,16 @@
           card.appendChild(gate);
         }
 
+        if (p.subskill) {
+          var sbadge = document.createElement('div');
+          sbadge.className = 'subskill-badge';
+          sbadge.style.background = p.color + '18';
+          sbadge.style.color = p.color;
+          sbadge.style.borderColor = p.color + '44';
+          sbadge.textContent = p.subskill;
+          card.appendChild(sbadge);
+        }
+
         card.addEventListener('click', function() { handleNodeClick(idx); });
         grid.appendChild(card);
       });
@@ -884,11 +969,44 @@
       });
     }
 
+    /* ===========================
+       SUB-SKILL CARDS
+    =========================== */
+    function buildSubskillCards() {
+      var grid = document.getElementById('subskillGrid');
+      grid.innerHTML = '';
+      SUBSKILLS.forEach(function(s) {
+        var card = document.createElement('div');
+        card.className = 'subskill-card';
+        card.style.borderLeftColor = s.color;
+
+        var cmd = document.createElement('div');
+        cmd.className = 'subskill-cmd';
+        cmd.style.color = s.color;
+        cmd.textContent = s.cmd;
+        card.appendChild(cmd);
+
+        var covers = document.createElement('div');
+        covers.className = 'subskill-covers';
+        covers.style.color = s.color;
+        covers.textContent = s.covers;
+        card.appendChild(covers);
+
+        var desc = document.createElement('div');
+        desc.className = 'subskill-desc';
+        desc.textContent = s.desc;
+        card.appendChild(desc);
+
+        grid.appendChild(card);
+      });
+    }
+
     function onThemeChange() { buildDiagram(); }
 
     /* === INIT (script is at end of body — DOM is ready) === */
     applyTheme(currentTheme);
     buildPhaseCards();
+    buildSubskillCards();
   </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #73

## 변경 사항

### docs/context-engineering-cycle.html

1. **Phase 카드 서브스킬 배지**
   - Step 0 · Phase 1 · Phase 2: `/context-engineering:gather`
   - Phase 3: `/context-engineering:spec`
   - Phase 4: `/context-engineering:impl`

2. **Sub-skills 요약 섹션 추가** (Phase 카드 아래)
   - 4개 서브스킬 카드: 명령어(monospace) + 커버 Phase + 사용 시점 설명
   - 각 카드 left border 색상은 담당 Phase color와 동일

3. **SUBSKILLS 데이터 배열 추가** (JS)
   - gather / spec / valid / impl 4종 정의