### PR TITLE
docs: README·HTML에 피드백 루프 개선사항 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,26 +91,30 @@ Step 0부터 Phase 4까지 순차 진행한다.
 ```
 Step 0 — Context Gathering
   · 요구사항 탐색 (무엇 · 왜 · 제약 — 질문 하나씩)
+  · 요약 확정 시 REQ-ID 부여 (REQ-1 · REQ-2 · REQ-3…)
   · 명확   → Phase 1~3 충실 작성 후 Phase 4 진입
   · 불명확 → 탐색 모드: 빈 초안 생성 → Phase 4 직행
                  ↓
-Phase 1 — Knowledge Base                  [사용자 확인]
+Phase 1 — Knowledge Base           [자체 평가] [사용자 확인]
   · Context Assessment — A/B/C/D 시나리오 판별
   · Source Scan  A: 대화  B: 문서 탐색  C: 코드  D: B+C
   · knowledge-base.md (Glossary · 제약 · 매니페스트)
                  ↓
-Phase 2 — Policy (CLAUDE.md)              [사용자 확인]
+Phase 2 — Policy (CLAUDE.md)       [자체 평가] [사용자 확인]
   · knowledge-base.md 링크 필수
   · Non-obvious Gotchas 초안 (Phase 4 피드백으로 갱신)
                  ↓
-Phase 3 — Spec                            [Readiness Gate]
-  · 아키텍처 결정 + 패키지 구조
+Phase 3 — Spec              [자체 평가] [Readiness Gate ⑥REQ]
+  · PRD 기능 요구사항 + SPEC 아키텍처 결정 + 패키지 구조
+  · 요구사항 추적 (REQ-ID → PRD 기능 → SPEC → 구현 계획)
   · Gate: AI가 현재 상태 요약 → 사용자가 통과 여부 결정
   ↑──────────────────── 미충족 시 해당 Phase 재순환
                  ↓  Gate 통과
-Phase 4 — Implementation
+Phase 4 — Implementation                          [회고]
   · 빌드 + 테스트 + PRD 성공 기준 달성
+  · 완료마다 REQ-ID 상태 갱신 (미구현 → 구현 완료)
   · 피드백 루프: 발견 내용 → 해당 Phase 문서 즉시 갱신
+  · 전체 완료 시 구현 회고 출력 (달성 · 프로세스 · 문서)
 ```
 
 **탐색 모드**: 요구사항 불명확 시 Phase 1~3을 빈 초안으로 생성하고 Phase 4로 바로 진입. 구현하며 채워나가다가 사용자가 직접 Readiness Gate를 요청해 본궤도로 전환한다.

--- a/docs/context-engineering-cycle.html
+++ b/docs/context-engineering-cycle.html
@@ -444,6 +444,7 @@
         confirmLabel: null,
         steps: [
           '요구사항 탐색 — 무엇·왜·제약 (질문 1개씩, 답변 후 다음)',
+          '요구사항 요약 확정 시 REQ-ID 부여 (REQ-1·REQ-2·REQ-3…)',
           '요구사항 요약 → 사용자 확인 (HARD-GATE)',
           '코드 경로(@인자) + 빌드 파일에서 기술 스택 자동 감지'
         ],
@@ -464,9 +465,10 @@
           'Source Scan — A: 대화 기반 / B: 스펙 탐색 / C: 코드 스캔 / D: B+C 병렬',
           'Domain Glossary 작성 (용어 테이블)',
           '제약 목록 작성 (TC/BL/OC 5컬럼)',
-          '참조 문서 매니페스트 작성'
+          '참조 문서 매니페스트 작성',
+          '자체 평가 — 용어 충분성·제약 분류·출처 명시 (일반 모드)'
         ],
-        gate: '일반 모드: Phase 1 완료 — knowledge-base.md 검토 후 Phase 2 진행할까요? / 탐색 모드: 확인 없이 Phase 2로 바로 진행.'
+        gate: '일반 모드: 자체 평가 테이블 출력 후 사용자 확인 — knowledge-base.md 검토 후 Phase 2 진행? / 탐색 모드: 자체 평가 생략, 확인 없이 Phase 2 진행.'
       },
       {
         id: 'phase2', label: 'Phase 2', name: 'Policy (CLAUDE.md)',
@@ -479,9 +481,10 @@
           '아키텍처 — 복잡한 서비스: Hexagonal+DDD / 단순 프로젝트: 자유 기술',
           '빌드 & 테스트 명령어 정리',
           'knowledge-base.md 링크 참고 문서 섹션에 필수 포함',
-          'Non-obvious Gotchas 초안 (Phase 4 피드백 루프에서 갱신)'
+          'Non-obvious Gotchas 초안 (Phase 4 피드백 루프에서 갱신)',
+          '자체 평가 — 빌드 명령어·High 제약 반영·KB 링크 (일반 모드)'
         ],
-        gate: '일반 모드: Phase 2 완료 — CLAUDE.md 초안 검토 후 Phase 3 진행할까요? / 탐색 모드: 확인 없이 Phase 3으로 바로 진행.'
+        gate: '일반 모드: 자체 평가 테이블 출력 후 사용자 확인 — CLAUDE.md 검토 후 Phase 3 진행? / 탐색 모드: 자체 평가 생략, 확인 없이 Phase 3 진행.'
       },
       {
         id: 'phase3', label: 'Phase 3', name: 'Spec',
@@ -493,10 +496,11 @@
           'PRD — 기능 요구사항 + 검증 가능한 성공 기준',
           'SPEC — 아키텍처 결정 (대안/선택/근거)',
           '패키지/모듈 구조 확정',
-          'SPEC 구현 계획 — 의존성·병렬 가능·완료 기준',
-          'Readiness Gate — AI가 현재 상태 요약, 사용자가 통과 여부 결정'
+          'SPEC 구현 계획 — 의존성·병렬 가능·완료 기준 (REQ 컬럼 포함)',
+          '요구사항 추적 테이블 — REQ-ID → PRD 기능 → SPEC 구현 매핑',
+          '자체 평가 후 Readiness Gate — AI 요약, 사용자 통과 여부 결정 (⑥ REQ 매핑 포함)'
         ],
-        gate: '일반 모드: 미충족 항목 → 해당 Phase 재순환. 탐색 모드: 사용자가 직접 Gate 요청 → 충족 시 본궤도 Phase 4 진입.'
+        gate: '일반 모드: 자체 평가 후 6항목 Gate 확인 (⑥ REQ 매핑 포함) — 미충족 → 해당 Phase 재순환. 탐색 모드: 사용자가 직접 Gate 요청 → 충족 시 Phase 4 진입.'
       },
       {
         id: 'phase4', label: 'Phase 4', name: 'Implementation',
@@ -509,7 +513,9 @@
           '빌드 + 테스트 통과 확인',
           'SPEC 아키텍처 결정 준수 확인',
           'PRD 기능별 성공 기준 달성 확인 (빌드 성공과 별개)',
-          '발견 내용 성격별 → Phase 1/2/3 해당 문서 즉시 갱신'
+          '완료마다 요구사항 추적 테이블 REQ-ID 상태 갱신 (미구현 → 구현 완료)',
+          '발견 내용 성격별 → Phase 1/2/3 해당 문서 즉시 갱신',
+          '전체 완료 시 구현 회고 출력 (요구사항 달성·프로세스·문서 최종 상태)'
         ],
         gate: null
       }


### PR DESCRIPTION
Closes #81

## 변경 내용

### README.md 워크플로우 블록
- **Step 0**: 요약 확정 시 REQ-ID 부여(REQ-1·REQ-2·REQ-3…) 언급 추가
- **Phase 1**: `[자체 평가]` 배지 추가, 자체 평가 항목 표기
- **Phase 2**: `[자체 평가]` 배지 추가, 자체 평가 항목 표기  
- **Phase 3**: `[자체 평가] [Readiness Gate ⑥REQ]` — 요구사항 추적 테이블 설명 추가
- **Phase 4**: `[회고]` 배지 추가, REQ-ID 상태 갱신 + 구현 회고 출력 언급

### docs/context-engineering-cycle.html
- **Step 0**: REQ-ID 부여 step 추가
- **Phase 1**: 자체 평가 step 추가 + gate 메시지 업데이트
- **Phase 2**: 자체 평가 step 추가 + gate 메시지 업데이트
- **Phase 3**: 요구사항 추적 테이블·자체 평가 step 추가 + gate 메시지 업데이트 (⑥ REQ 매핑 포함)
- **Phase 4**: REQ-ID 상태 갱신·구현 회고 step 추가