### PR TITLE
docs: translate Korean content to English for public distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "context-engineering",
-  "description": "AI 도구로 복잡한 서비스를 개발하는 4단계 Context Engineering 워크플로우 플러그인",
+  "description": "4-phase Context Engineering workflow plugin for developing complex services with AI tools",
   "owner": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "context-engineering",
-      "description": "AI 도구로 복잡한 서비스를 개발할 때 도메인 지식 수집 → Policy(CLAUDE.md) 작성 → 구현 Spec 설계 → 단계별 구현 검증을 위한 4단계 워크플로우",
+      "description": "4-phase workflow for developing complex services with AI tools: domain knowledge collection → Policy (CLAUDE.md) → Spec design → step-by-step implementation with verification",
       "version": "1.0.0",
       "author": {
         "name": "SeokRae",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "context-engineering",
   "version": "1.0.0",
-  "description": "AI 도구로 복잡한 서비스를 개발할 때의 4단계 Context Engineering 워크플로우: 도메인 지식 수집 → Policy 작성 → 구현 Spec → 단계별 구현",
+  "description": "4-phase Context Engineering workflow for developing complex services with AI tools: domain knowledge collection → Policy (CLAUDE.md) → implementation Spec → step-by-step implementation",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,25 +2,25 @@
 
 This file provides guidance to Claude Code when working with code in this repository.
 
-> AI 도구로 복잡한 서비스를 개발할 때의 4단계 Context Engineering 워크플로우 Claude Code 플러그인
+> 4-phase Context Engineering workflow Claude Code plugin for developing complex services with AI tools
 
-## 프로젝트 성격
+## Project Nature
 
-소스 코드 없음. **순수 마크다운** Claude Code 플러그인:
-- `plugin.json` — 플러그인 메타데이터
-- `skills/context-engineering/SKILL.md` — 전체 워크플로우 스킬 (Step 0 → Phase 4)
-- `skills/context-engineering/references/` — 각 Phase 산출물 템플릿
-- `skills/gather/SKILL.md` — 서브스킬: Step 0 + Phase 1 (KB) + Phase 2 (CLAUDE.md)
-- `skills/spec/SKILL.md` — 서브스킬: Phase 3 (PRD + SPEC)
-- `skills/valid/SKILL.md` — 서브스킬: Readiness Gate 검증
-- `skills/impl/SKILL.md` — 서브스킬: Phase 4 (구현)
+No source code. **Pure markdown** Claude Code plugin:
+- `plugin.json` — plugin metadata
+- `skills/context-engineering/SKILL.md` — full workflow skill (Step 0 → Phase 4)
+- `skills/context-engineering/references/` — phase artifact templates
+- `skills/gather/SKILL.md` — sub-skill: Step 0 + Phase 1 (KB) + Phase 2 (CLAUDE.md)
+- `skills/spec/SKILL.md` — sub-skill: Phase 3 (PRD + SPEC)
+- `skills/valid/SKILL.md` — sub-skill: Readiness Gate validation
+- `skills/impl/SKILL.md` — sub-skill: Phase 4 (implementation)
 
-## 스킬 수정 시 주의사항
+## Skill Modification Guidelines
 
-1. **변수 일관성**: `{OUTPUT_PATH}` 등 Step 0에서 정의한 변수만 이후 Phase에서 참조
-2. **템플릿 동기화**: `references/` 템플릿과 SKILL.md 본문의 산출물 구조 일치 유지
-3. **게이트 메시지 형식**: `"Phase {N} 완료 — \`{산출물}\` 초안을 저장했습니다. 검토 후 Phase {N+1} 진행할까요?"` 통일
+1. **Variable consistency**: only reference variables defined in Step 0 (e.g., `{OUTPUT_PATH}`) in later phases
+2. **Template sync**: keep `references/` templates and SKILL.md inline artifact structures in sync
+3. **Gate message format**: standardize to `"Phase {N} complete — \`{artifact}\` draft saved. Review and proceed to Phase {N+1}?"`
 
-## 검증
+## Verification
 
-스킬 변경 후 실제 프로젝트에서 `/context-engineering @<경로>`를 실행해 Step 0 파라미터 수집이 정상인지 확인.
+After modifying a skill, run `/context-engineering @<path>` in a real project to confirm Step 0 parameter collection works correctly.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
 # context-engineering
 
-AI 도구로 복잡한 서비스를 개발할 때 **"무엇을 알고, 어떻게 행동하고, 무엇을 만들어야 하는가"** 를 단계별로 정의하는 Claude Code 플러그인.
+A Claude Code plugin that defines step-by-step **"what to know, how to behave, and what to build"** when developing complex services with AI tools.
 
-## Context Engineering이란?
+## What is Context Engineering?
 
-Context Engineering은 **LLM의 컨텍스트 윈도우에 무엇을 넣을지 설계하는 기술**이다. 프롬프트 한 줄을 잘 쓰는 것을 넘어, 어떤 정보를 언제 어떤 구조로 AI에게 제공할지를 결정한다. RAG, 메모리 아키텍처, 토큰 예산 관리, 시스템 프롬프트 설계 등이 모두 이 범주에 속한다.
+Context Engineering is **the practice of designing what goes into an LLM's context window**. It goes beyond writing a single good prompt — it decides what information to give to AI, when, and in what structure. RAG, memory architecture, token budget management, and system prompt design all fall under this category.
 
-이 플러그인은 그 중 **지속성 컨텍스트 준비(persistent context preparation)** 한 가지를 다룬다 — 개발 세션마다 AI가 올바른 도메인 지식과 행동 규칙을 가지고 시작하도록 `knowledge-base.md`와 `CLAUDE.md`를 체계적으로 만들고 유지하는 워크플로우다.
+This plugin addresses one aspect of that — **persistent context preparation** — a workflow to systematically create and maintain `knowledge-base.md` and `CLAUDE.md` so AI starts each development session with the right domain knowledge and behavior rules.
 
-## 개요
+## Overview
 
-복잡한 서비스를 AI와 함께 개발할 때 세 가지 질문에 답해야 한다:
+When developing complex services with AI, three questions must be answered:
 
-- **무엇을 알아야 하는가** → Knowledge Base (도메인 지식, 제약)
-- **어떻게 행동해야 하는가** → Policy (CLAUDE.md)
-- **무엇을 만들어야 하는가** → Spec (PRD + 기술 결정 + 구현 계획)
+- **What to know** → Knowledge Base (domain knowledge, constraints)
+- **How to behave** → Policy (CLAUDE.md)
+- **What to build** → Spec (PRD + architecture decisions + implementation plan)
 
-이 플러그인은 두 가지 방식으로 사용할 수 있다:
+This plugin can be used in two ways:
 
-- **`/context-engineering`** — Step 0부터 Phase 4까지 순차 진행 (전체 워크플로우)
-- **Sub-skills** — 특정 Phase에 직접 진입 (재작업·피드백 루프용)
+- **`/context-engineering`** — Sequential flow from Step 0 to Phase 4 (full workflow)
+- **Sub-skills** — Direct entry to a specific phase (for rework or feedback loop)
 
-## 설치
+## Installation
 
 ```bash
-# 1. 마켓플레이스 등록
+# 1. Add to marketplace
 claude plugin marketplace add https://github.com/SeokRae/context-engineering.git
 
-# 2. 플러그인 설치
+# 2. Install plugin
 claude plugin install context-engineering
 ```
 
-설치 후 Claude Code를 재시작해야 적용된다.
+Restart Claude Code after installation for changes to take effect.
 
-설치 확인:
+Verify installation:
 ```bash
 claude plugin list
 #   ❯ context-engineering@context-engineering
@@ -42,40 +42,40 @@ claude plugin list
 #     Status: ✔ enabled
 ```
 
-로컬 디렉토리에서 바로 사용할 때:
+To use directly from a local directory:
 ```bash
 claude --plugin-dir /path/to/context-engineering
 ```
 
-## 스킬
+## Skills
 
-### `/context-engineering` — 전체 워크플로우
+### `/context-engineering` — Full workflow
 
-Step 0부터 Phase 4까지 순차 진행한다.
+Runs sequentially from Step 0 through Phase 4.
 
 ```
-/context-engineering @<코드경로> [--output <출력경로>] [--specs <스펙문서경로>]
+/context-engineering @<code-path> [--output <output-path>] [--specs <spec-doc-path>]
 ```
 
-**예시:**
+**Examples:**
 ```
 /context-engineering @/path/to/project
 /context-engineering @/path/to/project --specs docs/references/
 /context-engineering @/path/to/project --output /tmp/context-docs --specs docs/references/
 ```
 
-### Sub-skills — Phase별 직접 진입
+### Sub-skills — Direct entry by phase
 
-이미 진행 중인 프로젝트에서 특정 Phase만 재작업하거나, 피드백 루프로 특정 Phase로 돌아가는 경우 사용한다.
+Use when reworking a specific phase in an ongoing project, or returning to a phase via the feedback loop.
 
-| 명령 | 담당 | 사용 시점 |
-|------|------|---------|
-| `/context-engineering:gather` | Step 0 + Phase 1 (KB) + Phase 2 (CLAUDE.md) | 새 프로젝트 시작, KB·CLAUDE.md 재작업·갱신 |
-| `/context-engineering:spec` | Phase 3 — PRD + SPEC | 요구사항·기술 명세 작성·갱신 |
-| `/context-engineering:impl` | Phase 4 — 구현 | 구현 시작, 피드백 루프 진입 |
-| `/context-engineering:valid` | Readiness Gate | Phase 4 진입 전 검증, 탐색 모드 종료 체크 |
+| Command | Handles | When to use |
+|---------|---------|-------------|
+| `/context-engineering:gather` | Step 0 + Phase 1 (KB) + Phase 2 (CLAUDE.md) | New project start, KB or CLAUDE.md rework/update |
+| `/context-engineering:spec` | Phase 3 — PRD + SPEC | Writing or updating requirements and technical spec |
+| `/context-engineering:impl` | Phase 4 — Implementation | Starting implementation, entering feedback loop |
+| `/context-engineering:valid` | Readiness Gate | Pre-Phase 4 validation, discovery mode exit check |
 
-각 sub-skill은 기존 artifacts(knowledge-base.md, CLAUDE.md, prd.md, spec.md)가 있으면 자동 탐지해 재작업/갱신을 선택할 수 있다.
+Each sub-skill auto-detects existing artifacts (knowledge-base.md, CLAUDE.md, prd.md, spec.md) and offers rework or update options.
 
 ```
 /context-engineering:gather @/path/to/project
@@ -84,52 +84,52 @@ Step 0부터 Phase 4까지 순차 진행한다.
 /context-engineering:impl @/path/to/project
 ```
 
-## 워크플로우
+## Workflow
 
-> **[📊 인터랙티브 다이어그램](https://seokrae.github.io/context-engineering/context-engineering-cycle.html)** — 각 Phase를 클릭하면 단계별 작업 내용을 확인할 수 있다.
+> **[📊 Interactive Diagram](https://seokrae.github.io/context-engineering/context-engineering-cycle.html)** — Click each phase to see the step-by-step details.
 
 ```
 Step 0 — Context Gathering
-  · 요구사항 탐색 (무엇 · 왜 · 제약 — 질문 하나씩)
-  · 요약 확정 시 REQ-ID 부여 (REQ-1 · REQ-2 · REQ-3…)
-  · 명확   → Phase 1~3 충실 작성 후 Phase 4 진입
-  · 불명확 → 탐색 모드: 빈 초안 생성 → Phase 4 직행
+  · Requirements exploration (What · Why · Constraints — one question at a time)
+  · Assign REQ-IDs when summary is confirmed (REQ-1 · REQ-2 · REQ-3…)
+  · Clear     → write Phase 1~3 thoroughly, then enter Phase 4
+  · Unclear   → discovery mode: generate empty drafts → go directly to Phase 4
                  ↓
-Phase 1 — Knowledge Base           [자체 평가] [사용자 확인]
-  · Context Assessment — A/B/C/D 시나리오 판별
-  · Source Scan  A: 대화  B: 문서 탐색  C: 코드  D: B+C
-  · knowledge-base.md (Glossary · 제약 · 매니페스트)
+Phase 1 — Knowledge Base           [Self-Assessment] [User confirmation]
+  · Context Assessment — A/B/C/D scenario detection
+  · Source Scan  A: conversation  B: spec docs  C: code  D: B+C
+  · knowledge-base.md (Glossary · Constraints · Manifest)
                  ↓
-Phase 2 — Policy (CLAUDE.md)       [자체 평가] [사용자 확인]
-  · knowledge-base.md 링크 필수
-  · Non-obvious Gotchas 초안 (Phase 4 피드백으로 갱신)
+Phase 2 — Policy (CLAUDE.md)       [Self-Assessment] [User confirmation]
+  · knowledge-base.md link required
+  · Non-obvious Gotchas draft (updated via Phase 4 feedback)
                  ↓
-Phase 3 — Spec              [자체 평가] [Readiness Gate ⑥REQ]
-  · PRD 기능 요구사항 + SPEC 아키텍처 결정 + 패키지 구조
-  · 요구사항 추적 (REQ-ID → PRD 기능 → SPEC → 구현 계획)
-  · Gate: AI가 현재 상태 요약 → 사용자가 통과 여부 결정
-  ↑──────────────────── 미충족 시 해당 Phase 재순환
-                 ↓  Gate 통과
-Phase 4 — Implementation                          [회고]
-  · 빌드 + 테스트 + PRD 성공 기준 달성
-  · 완료마다 REQ-ID 상태 갱신 (미구현 → 구현 완료)
-  · 피드백 루프: 발견 내용 → 해당 Phase 문서 즉시 갱신
-  · 전체 완료 시 구현 회고 출력 (달성 · 프로세스 · 문서)
+Phase 3 — Spec              [Self-Assessment] [Readiness Gate ⑥REQ]
+  · PRD feature requirements + SPEC architecture decisions + package structure
+  · Requirements traceability (REQ-ID → PRD feature → SPEC → implementation plan)
+  · Gate: AI summarizes current state → user decides pass/fail
+  ↑──────────────────── re-cycle to relevant phase if unmet
+                 ↓  Gate passed
+Phase 4 — Implementation                          [Retrospective]
+  · Build + Test + PRD success criteria achieved
+  · Update REQ-ID status on each completion (not implemented → implemented)
+  · Feedback loop: findings → immediately update the relevant phase document
+  · Output Implementation Retrospective when all done (achievement · process · documents)
 ```
 
-**탐색 모드**: 요구사항 불명확 시 Phase 1~3을 빈 초안으로 생성하고 Phase 4로 바로 진입. 구현하며 채워나가다가 사용자가 직접 Readiness Gate를 요청해 본궤도로 전환한다.
+**Discovery mode**: When requirements are unclear, generate Phase 1~3 as empty drafts and go directly to Phase 4. Fill in while developing, then switch to the main track when the user requests the Readiness Gate.
 
-## 참고 문서
+## Reference Documents
 
-각 Phase 산출물 템플릿은 `skills/context-engineering/references/` 에 있다:
+Phase artifact templates are in `skills/context-engineering/references/`:
 
-| 파일 | 용도 |
-|------|------|
-| [`phase-checklist.md`](skills/context-engineering/references/phase-checklist.md) | 프로젝트별 진행 체크리스트 |
-| [`knowledge-base-template.md`](skills/context-engineering/references/knowledge-base-template.md) | Phase 1 산출물 템플릿 |
-| [`claude-md-policy-template.md`](skills/context-engineering/references/claude-md-policy-template.md) | Phase 2 CLAUDE.md 템플릿 |
-| [`spec-template.md`](skills/context-engineering/references/spec-template.md) | Phase 3 SPEC 템플릿 (아키텍처 결정 + 패키지 구조) |
-| [`architecture-principles.md`](skills/context-engineering/references/architecture-principles.md) | Hexagonal + DDD 원칙 (복잡한 서비스용, 선택 적용) |
+| File | Purpose |
+|------|---------|
+| [`phase-checklist.md`](skills/context-engineering/references/phase-checklist.md) | Per-project progress checklist |
+| [`knowledge-base-template.md`](skills/context-engineering/references/knowledge-base-template.md) | Phase 1 artifact template |
+| [`claude-md-policy-template.md`](skills/context-engineering/references/claude-md-policy-template.md) | Phase 2 CLAUDE.md template |
+| [`spec-template.md`](skills/context-engineering/references/spec-template.md) | Phase 3 SPEC template (architecture decisions + package structure) |
+| [`architecture-principles.md`](skills/context-engineering/references/architecture-principles.md) | Hexagonal + DDD principles (for complex services, optional) |
 
 ## License
 

--- a/docs/context-engineering-cycle.html
+++ b/docs/context-engineering-cycle.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko" class="theme-dark">
+<html lang="en" class="theme-dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -283,67 +283,67 @@
   <main id="main-content" role="main">
     <section class="page-header">
       <h1 class="animate">Context Engineering Cycle</h1>
-      <p class="animate delay-1">AI 도구로 복잡한 서비스를 개발하는 반복 가능한 5단계 워크플로우</p>
+      <p class="animate delay-1">A repeatable 5-step workflow for developing complex services with AI tools</p>
     </section>
 
     <section class="diagram-wrap animate delay-2" aria-label="Context Engineering cycle diagram">
       <svg id="cycle-svg" viewBox="0 0 980 820" xmlns="http://www.w3.org/2000/svg"
-           role="img" aria-label="Step 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → 피드백 루프 순환 다이어그램">
-        <!-- JS로 그림 -->
+           role="img" aria-label="Step 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → feedback loop cycle diagram">
+        <!-- drawn by JS -->
       </svg>
     </section>
 
     <div class="legend animate delay-3">
       <div class="legend-item">
         <div class="legend-line solid"></div>
-        <span>메인 플로우</span>
+        <span>Main flow</span>
       </div>
       <div class="legend-item">
         <div class="legend-line dashed"></div>
-        <span>Spec 갱신 (Phase 4 → 3)</span>
+        <span>Spec update (Phase 4 → 3)</span>
       </div>
       <div class="legend-item">
         <div class="legend-line dashed" style="background: repeating-linear-gradient(90deg, #06b6d4 0, #06b6d4 4px, transparent 4px, transparent 9px);"></div>
-        <span>KB 갱신 (Phase 4 → 1)</span>
+        <span>KB update (Phase 4 → 1)</span>
       </div>
       <div class="legend-item">
         <div class="legend-line dashed" style="background: linear-gradient(90deg, #f59e0b 60%, transparent 60%); background-size: 10px 2px;"></div>
-        <span>재순환 (Readiness Gate 미충족)</span>
+        <span>Re-cycle (Readiness Gate unmet)</span>
       </div>
     </div>
 
     <section class="cards-section" data-reveal>
-      <h2>단계별 작업 내용</h2>
+      <h2>Phase Details</h2>
       <div class="cards-grid" id="phaseCardsGrid"></div>
     </section>
 
     <section class="subskill-section" data-reveal>
-      <h2>Sub-skills — Phase별 직접 진입</h2>
+      <h2>Sub-skills — Direct Phase Entry</h2>
       <div class="subskill-grid" id="subskillGrid"></div>
     </section>
 
     <section class="scenario-section" data-reveal>
-      <h2>Phase 1 시나리오 분기</h2>
+      <h2>Phase 1 Scenario Branching</h2>
       <div class="scenario-grid">
         <div class="scenario-card">
-          <div class="scenario-id" style="color:#10b981;">A. 그린필드</div>
-          <div class="scenario-title">아무것도 없음</div>
-          <div class="scenario-desc">Step 0 대화에서 용어·제약 직접 추출. 최소 Knowledge Base로 Phase 2 진행.</div>
+          <div class="scenario-id" style="color:#10b981;">A. Greenfield</div>
+          <div class="scenario-title">Nothing yet</div>
+          <div class="scenario-desc">Extract terms and constraints directly from Step 0 conversation. Proceed to Phase 2 with a minimal Knowledge Base.</div>
         </div>
         <div class="scenario-card">
-          <div class="scenario-id" style="color:#3b82f6;">B. 스펙 문서</div>
-          <div class="scenario-title">--specs 문서 있음</div>
-          <div class="scenario-desc">병렬 Explore 에이전트로 문서 탐색 → 용어·제약·참조 매니페스트 작성.</div>
+          <div class="scenario-id" style="color:#3b82f6;">B. Spec docs</div>
+          <div class="scenario-title">--specs documents available</div>
+          <div class="scenario-desc">Explore documents with parallel Explore agents → write terms, constraints, and reference manifest.</div>
         </div>
         <div class="scenario-card">
-          <div class="scenario-id" style="color:#f59e0b;">C. 기존 코드</div>
-          <div class="scenario-title">코드베이스 있음</div>
-          <div class="scenario-desc">코드 스캔 → 기존 패턴·용어·제약 추출. 충돌 가능성 사전 파악.</div>
+          <div class="scenario-id" style="color:#f59e0b;">C. Existing code</div>
+          <div class="scenario-title">Codebase available</div>
+          <div class="scenario-desc">Code scan → extract existing patterns, terms, and constraints. Identify potential conflicts early.</div>
         </div>
         <div class="scenario-card">
-          <div class="scenario-id" style="color:#8b5cf6;">D. 둘 다</div>
-          <div class="scenario-title">코드 + 스펙</div>
-          <div class="scenario-desc">B + C 병렬 수행. 가장 풍부한 Knowledge Base. 불일치 감지 포함.</div>
+          <div class="scenario-id" style="color:#8b5cf6;">D. Both</div>
+          <div class="scenario-title">Code + Spec</div>
+          <div class="scenario-desc">Run B + C in parallel. Richest Knowledge Base. Includes inconsistency detection.</div>
         </div>
       </div>
     </section>
@@ -417,25 +417,25 @@
         cmd: '/context-engineering:gather',
         covers: 'Step 0 · Phase 1 · Phase 2',
         color: '#6366f1',
-        desc: '새 프로젝트 시작 또는 KB·CLAUDE.md 재작업·갱신. 요구사항 탐색 → Knowledge Base → Policy(CLAUDE.md) 작성.'
+        desc: 'New project start or KB·CLAUDE.md rework/update. Requirements exploration → Knowledge Base → Policy (CLAUDE.md).'
       },
       {
         cmd: '/context-engineering:spec',
         covers: 'Phase 3',
         color: '#f59e0b',
-        desc: 'PRD(제품 요구사항) + SPEC(기술 명세) 작성. 기존 문서가 있으면 자동 탐지해 갱신.'
+        desc: 'Write PRD (product requirements) + SPEC (technical spec). Auto-detects existing documents for update.'
       },
       {
         cmd: '/context-engineering:valid',
         covers: 'Readiness Gate',
         color: '#8b5cf6',
-        desc: 'Phase 4 진입 전 체크포인트. AI가 현재 상태 요약 → 사용자가 통과 여부 결정.'
+        desc: 'Checkpoint before entering Phase 4. AI summarizes current state → user decides pass/fail.'
       },
       {
         cmd: '/context-engineering:impl',
         covers: 'Phase 4',
         color: '#10b981',
-        desc: 'SPEC 구현 계획 순서대로 구현. 완료 기준 검증 + 피드백 루프 반복.'
+        desc: 'Implement in SPEC plan order. Verify done criteria + repeat feedback loop.'
       }
     ];
 
@@ -447,14 +447,14 @@
         subskill: '/context-engineering:gather',
         confirmLabel: null,
         steps: [
-          '요구사항 탐색 — 무엇·왜·제약 (질문 1개씩, 답변 후 다음)',
-          '요구사항 요약 확정 시 REQ-ID 부여 (REQ-1·REQ-2·REQ-3…)',
-          '요구사항 요약 → 사용자 확인 (HARD-GATE)',
-          '코드 경로(@인자) + 빌드 파일에서 기술 스택 자동 감지'
+          'Requirements exploration — What·Why·Constraints (one question at a time, wait for answer)',
+          'Assign REQ-IDs when summary is confirmed (REQ-1·REQ-2·REQ-3…)',
+          'Requirements summary → user confirmation (HARD-GATE)',
+          'Auto-detect tech stack from code path (@arg) + build files'
         ],
         branches: [
-          { label: '명확', desc: 'Phase 1~3 충실 작성 후 Phase 4 진입' },
-          { label: '불명확', desc: '탐색 모드: 빈 초안 생성 → Phase 4 직행' }
+          { label: 'Clear', desc: 'Write Phase 1~3 thoroughly, then enter Phase 4' },
+          { label: 'Unclear', desc: 'Discovery mode: generate empty drafts → go directly to Phase 4' }
         ],
         gate: null
       },
@@ -463,32 +463,32 @@
         angle: -18, color: '#3b82f6',
         icon: 'book',
         subskill: '/context-engineering:gather',
-        confirmLabel: '사용자 확인',
+        confirmLabel: 'User confirmation',
         steps: [
-          'Context Assessment — A/B/C/D 판별 후 사용자 확인 필수',
-          'Source Scan — A: 대화 기반 / B: 스펙 탐색 / C: 코드 스캔 / D: B+C 병렬',
-          'Domain Glossary 작성 (용어 테이블)',
-          '제약 목록 작성 (TC/BL/OC 5컬럼)',
-          '참조 문서 매니페스트 작성',
-          '자체 평가 — 용어 충분성·제약 분류·출처 명시 (일반 모드)'
+          'Context Assessment — detect A/B/C/D scenario, user confirmation required',
+          'Source Scan — A: conversation / B: spec docs / C: code scan / D: B+C parallel',
+          'Write Domain Glossary (term table)',
+          'Write Constraint Registry (TC/BL/OC 5-column)',
+          'Write Reference Document Manifest',
+          'Self-Assessment — term sufficiency, constraint categories, source attribution (normal mode)'
         ],
-        gate: '일반 모드: 자체 평가 테이블 출력 후 사용자 확인 — knowledge-base.md 검토 후 Phase 2 진행? / 탐색 모드: 자체 평가 생략, 확인 없이 Phase 2 진행.'
+        gate: 'Normal mode: output Self-Assessment table then user confirmation — review knowledge-base.md, proceed to Phase 2? / Discovery mode: skip Self-Assessment, proceed to Phase 2 without confirmation.'
       },
       {
         id: 'phase2', label: 'Phase 2', name: 'Policy (CLAUDE.md)',
         angle: 54, color: '#8b5cf6',
         icon: 'shield',
         subskill: '/context-engineering:gather',
-        confirmLabel: '사용자 확인',
+        confirmLabel: 'User confirmation',
         steps: [
-          'CLAUDE.md 레벨 결정 (프로젝트/모듈)',
-          '아키텍처 — 복잡한 서비스: Hexagonal+DDD / 단순 프로젝트: 자유 기술',
-          '빌드 & 테스트 명령어 정리',
-          'knowledge-base.md 링크 참고 문서 섹션에 필수 포함',
-          'Non-obvious Gotchas 초안 (Phase 4 피드백 루프에서 갱신)',
-          '자체 평가 — 빌드 명령어·High 제약 반영·KB 링크 (일반 모드)'
+          'Decide CLAUDE.md level (project/module)',
+          'Architecture — complex service: Hexagonal+DDD / simple project: describe freely',
+          'Set up Build & Test commands',
+          'Must include knowledge-base.md link in References section',
+          'Non-obvious Gotchas draft (updated via Phase 4 feedback loop)',
+          'Self-Assessment — build commands, High constraints reflected, KB link (normal mode)'
         ],
-        gate: '일반 모드: 자체 평가 테이블 출력 후 사용자 확인 — CLAUDE.md 검토 후 Phase 3 진행? / 탐색 모드: 자체 평가 생략, 확인 없이 Phase 3 진행.'
+        gate: 'Normal mode: output Self-Assessment table then user confirmation — review CLAUDE.md, proceed to Phase 3? / Discovery mode: skip Self-Assessment, proceed to Phase 3 without confirmation.'
       },
       {
         id: 'phase3', label: 'Phase 3', name: 'Spec',
@@ -497,14 +497,14 @@
         subskill: '/context-engineering:spec',
         confirmLabel: 'Readiness Gate',
         steps: [
-          'PRD — 기능 요구사항 + 검증 가능한 성공 기준',
-          'SPEC — 아키텍처 결정 (대안/선택/근거)',
-          '패키지/모듈 구조 확정',
-          'SPEC 구현 계획 — 의존성·병렬 가능·완료 기준 (REQ 컬럼 포함)',
-          '요구사항 추적 테이블 — REQ-ID → PRD 기능 → SPEC 구현 매핑',
-          '자체 평가 후 Readiness Gate — AI 요약, 사용자 통과 여부 결정 (⑥ REQ 매핑 포함)'
+          'PRD — feature requirements + verifiable success criteria',
+          'SPEC — architecture decisions (alternatives/choice/rationale)',
+          'Finalize package/module structure',
+          'SPEC implementation plan — dependencies, parallelizable, done criteria (REQ column included)',
+          'Requirements traceability table — REQ-ID → PRD feature → SPEC implementation mapping',
+          'Self-Assessment then Readiness Gate — AI summarizes, user decides pass/fail (⑥ REQ mapping included)'
         ],
-        gate: '일반 모드: 자체 평가 후 6항목 Gate 확인 (⑥ REQ 매핑 포함) — 미충족 → 해당 Phase 재순환. 탐색 모드: 사용자가 직접 Gate 요청 → 충족 시 Phase 4 진입.'
+        gate: 'Normal mode: Self-Assessment then 6-item Gate check (⑥ REQ mapping included) — unmet → re-cycle to relevant phase. Discovery mode: user requests Gate directly → pass leads to Phase 4.'
       },
       {
         id: 'phase4', label: 'Phase 4', name: 'Implementation',
@@ -513,13 +513,13 @@
         subskill: '/context-engineering:impl',
         confirmLabel: null,
         steps: [
-          'SPEC 구현 계획 순서대로 구현',
-          '빌드 + 테스트 통과 확인',
-          'SPEC 아키텍처 결정 준수 확인',
-          'PRD 기능별 성공 기준 달성 확인 (빌드 성공과 별개)',
-          '완료마다 요구사항 추적 테이블 REQ-ID 상태 갱신 (미구현 → 구현 완료)',
-          '발견 내용 성격별 → Phase 1/2/3 해당 문서 즉시 갱신',
-          '전체 완료 시 구현 회고 출력 (요구사항 달성·프로세스·문서 최종 상태)'
+          'Implement in SPEC plan order',
+          'Verify build + tests pass',
+          'Verify SPEC architecture decisions are followed',
+          'Verify PRD per-feature success criteria achieved (separate from build success)',
+          'Update requirements traceability table REQ-ID status on each completion (not implemented → implemented)',
+          'Based on finding type → immediately update the relevant Phase 1/2/3 document',
+          'Output Implementation Retrospective when all done (requirements achieved · process · final document state)'
         ],
         gate: null
       }
@@ -790,7 +790,7 @@
           fill: textColor, 'font-size': '11',
           'font-family': 'Noto Sans KR, Inter, sans-serif', 'font-weight': '600'
         });
-        lbl.textContent = 'Spec 갱신';
+        lbl.textContent = 'Spec update';
         svg.appendChild(lbl);
       })();
 
@@ -819,7 +819,7 @@
         });
         svg.appendChild(path);
 
-        // Label at t=0.2 (Phase 3 쪽) — 중앙 텍스트와 겹침 방지
+        // Label at t=0.2 (Phase 3 side) — avoid overlap with center text
         var lx = 0.64*sx + 0.32*cp_x + 0.04*ex;
         var ly = 0.64*sy + 0.32*cp_y + 0.04*ey;
 
@@ -834,11 +834,11 @@
           fill: refineColor, 'font-size': '11',
           'font-family': 'Noto Sans KR, Inter, sans-serif', 'font-weight': '600'
         });
-        lbl.textContent = '재순환';
+        lbl.textContent = 'Re-cycle';
         svg.appendChild(lbl);
       })();
 
-      /* --- FEEDBACK ARROW: Phase 4 → Phase 1 (KB/Policy 갱신, dashed cyan) --- */
+      /* --- FEEDBACK ARROW: Phase 4 → Phase 1 (KB/Policy update, dashed cyan) --- */
       (function() {
         var f = PHASES[4], t = PHASES[1]; // Phase 4 → Phase 1
         var dx = t.cx - f.cx, dy = t.cy - f.cy;
@@ -878,7 +878,7 @@
           fill: kbColor, 'font-size': '11',
           'font-family': 'Noto Sans KR, Inter, sans-serif', 'font-weight': '600'
         });
-        lbl.textContent = 'KB 갱신';
+        lbl.textContent = 'KB update';
         svg.appendChild(lbl);
       })();
 
@@ -970,7 +970,7 @@
         overlay.addEventListener('click', function() { handleNodeClick(idx); });
         g.appendChild(overlay);
 
-        // Gate badge: Phase 1/2/3 자체 평가 표시 (directly above each node)
+        // Gate badge: Phase 1/2/3 Self-Assessment indicator (directly above each node)
         if (p.confirmLabel) {
           var bx = p.cx;
           var by = p.cy - NR - 16;
@@ -986,7 +986,7 @@
             fill: p.color, 'font-size': '8.5',
             'font-family': 'Noto Sans KR, Inter, sans-serif', 'font-weight': '700'
           });
-          btxt.textContent = '✓ 자체 평가';
+          btxt.textContent = '✓ Self-Assess';
           g.appendChild(btxt);
         }
 

--- a/skills/context-engineering/references/architecture-principles.md
+++ b/skills/context-engineering/references/architecture-principles.md
@@ -1,67 +1,67 @@
-# 아키텍처 원칙
+# Architecture Principles
 
-Phase 3 패키지/모듈 구조 설계 시 **선택적으로** 참조한다.
+**Optionally** referenced during Phase 3 package/module structure design.
 
-> **적용 대상**: 외부 API 연동, 복잡한 비즈니스 규칙, 도메인 모델이 필요한 서비스.
-> 단순 CLI 스크립트·데이터 파이프라인·분석 도구는 이 원칙 대신 프로젝트에 맞는 구조를 직접 정의한다.
+> **Applies to**: Services requiring external API integration, complex business rules, or a domain model.
+> Simple CLI scripts, data pipelines, and analysis tools should define their own structure directly instead of following these principles.
 
-## 언제 이 원칙을 사용하는가
+## When to use these principles
 
-| 프로젝트 유형 | 적용 | 대안 |
-|-------------|:---:|------|
-| REST API (외부 의존성 多) | ✅ | — |
-| 도메인 로직이 복잡한 서비스 | ✅ | — |
-| CLI 스크립트, 단발성 도구 | ❌ | 단순 모듈 분리 |
-| ML 파이프라인, 데이터 분석 | ❌ | 스테이지 기반 구조 |
-| 라이브러리 / SDK | ⚠️ | 공개 API 중심 구조 |
+| Project type | Recommended | Alternative |
+|-------------|:-----------:|-------------|
+| REST API (many external dependencies) | ✅ | — |
+| Service with complex domain logic | ✅ | — |
+| CLI scripts, one-off tools | ❌ | Simple module separation |
+| ML pipelines, data analysis | ❌ | Stage-based structure |
+| Library / SDK | ⚠️ | Public API-centric structure |
 
 ---
 
-## 왜 레이어를 나누는가 (SoC + Cohesion/Coupling)
+## Why separate layers (SoC + Cohesion/Coupling)
 
-- **High Cohesion**: 같은 이유로 변경되는 코드는 같은 모듈에
-- **Low Coupling**: 다른 이유로 변경되는 코드는 다른 모듈로 분리
-- **SoC**: 하나의 모듈은 하나의 관심사(도메인 규칙 / 기술 세부사항 / 입출력 변환)만
+- **High Cohesion**: Code that changes for the same reason belongs in the same module
+- **Low Coupling**: Code that changes for different reasons should be separated into different modules
+- **SoC**: Each module handles a single concern (domain rules / technical details / input-output transformation)
 
-> SOLID는 이 원칙의 OOP 구체화. DDD는 도메인 관심사를 비즈니스 언어로 명시.
+> SOLID is the OOP concretization of these principles. DDD expresses domain concerns in business language.
 
-## 레이어 설계 (Ports & Adapters + DDD)
+## Layer design (Ports & Adapters + DDD)
 
-| 레이어 | Ports & Adapters | 책임 (SRP) | 의존 규칙 (DIP) | DDD 개념 |
-|--------|-----------------|-----------|----------------|---------|
-| 도메인 | — (순수 도메인) | 비즈니스 규칙·불변식 | 외부 의존 없음 (순수) | Entity, Value Object, Aggregate, Domain Service, Repository 포트(인터페이스) |
-| 애플리케이션 | — (Use Case) | 유스케이스 조율 (CQS 적용) | 도메인만 | Application Service, Command Handler, Query Handler |
-| 인프라 | Driven Adapter (Secondary) | 외부 시스템 구현체 | 도메인 포트 역전(DIP) | Repository 구현, External API Adapter |
-| 진입점 | Driving Adapter (Primary) | 입력 수신·변환 | 애플리케이션만 | HTTP Controller, Message Consumer |
-| 설정 | — | 의존성 조립 | 전 레이어 | DI 설정, 환경 변수 바인딩 |
+| Layer | Ports & Adapters | Responsibility (SRP) | Dependency rule (DIP) | DDD concepts |
+|-------|-----------------|---------------------|----------------------|-------------|
+| domain | — (pure domain) | Business rules and invariants | No external dependencies (pure) | Entity, Value Object, Aggregate, Domain Service, Repository port (interface) |
+| application | — (Use Case) | Use case orchestration (CQS applied) | domain only | Application Service, Command Handler, Query Handler |
+| infrastructure | Driven Adapter (Secondary) | External system implementations | Inverted via domain port (DIP) | Repository implementation, External API Adapter |
+| entry | Driving Adapter (Primary) | Input reception and transformation | application only | HTTP Controller, Message Consumer |
+| config | — | Dependency assembly | All layers | DI configuration, environment variable binding |
 
-의존 방향: `진입점(Primary) → 애플리케이션 → 도메인 ← 인프라(Secondary)` (역방향 금지)
+Dependency direction: `entry (Primary) -> application -> domain <- infrastructure (Secondary)` (reverse direction forbidden)
 
-## 책임 할당 — GRASP Information Expert
+## Responsibility assignment — GRASP Information Expert
 
-책임은 그 정보를 가진 객체에 둔다:
-- 주문 총액 계산 → `Order` (항목 정보를 가진 쪽이 책임 — OrderService 아님)
-- 할인 정책 적용 → `DiscountPolicy` (정책 규칙을 아는 쪽이 책임 — Order 아님)
-- 재고 확인 → `Inventory` (재고 수량을 가진 쪽이 책임)
+Assign responsibility to the object that holds the relevant information:
+- Order total calculation → `Order` (the side that holds item data is responsible — not OrderService)
+- Discount policy application → `DiscountPolicy` (the side that knows the policy rules is responsible — not Order)
+- Inventory check → `Inventory` (the side that holds stock quantity is responsible)
 
-## CQS — Application Service 설계 기준
+## CQS — Application Service design criteria
 
-Application Service의 메서드는 둘 중 하나만:
-- **Command**: 상태 변경 + 반환값 없음 — `createOrder()`, `cancelPayment()`
-- **Query**: 상태 변경 없음 + 값 반환 — `getOrderById()`, `listPendingOrders()`
+Each Application Service method does exactly one of the following:
+- **Command**: state change + no return value — `createOrder()`, `cancelPayment()`
+- **Query**: no state change + returns a value — `getOrderById()`, `listPendingOrders()`
 
-## OCP 적용 기준
+## OCP application criteria
 
-- 비즈니스 규칙 변경 → 도메인 레이어만 수정
-- 외부 API 교체 → 인프라(Secondary Adapter)만 수정 (도메인·애플리케이션 무변경)
-- 새 유스케이스 추가 → 애플리케이션 레이어 확장 (기존 코드 닫힘)
+- Business rule change → modify domain layer only
+- External API replacement → modify infrastructure (Secondary Adapter) only (domain and application unchanged)
+- New use case addition → extend application layer (existing code remains closed)
 
-## 언어별 폴더명 대응
+## Language-specific folder names
 
-| 레이어 | Java | Node.js | Python | Go |
-|--------|------|---------|--------|----|
-| 도메인 | `domain/` | `domain/` | `domain/` | `internal/domain/` |
-| 애플리케이션 | `application/` | `services/` | `services/` | `internal/service/` |
-| 인프라 | `infrastructure/` | `repositories/` | `infra/` | `internal/repository/` |
-| 진입점 | `adapter/in/` | `routes/` | `api/` | `internal/handler/` |
-| 설정 | `config/` | `config/` | `core/` | `internal/config/` |
+| Layer | Java | Node.js | Python | Go |
+|-------|------|---------|--------|----|
+| domain | `domain/` | `domain/` | `domain/` | `internal/domain/` |
+| application | `application/` | `services/` | `services/` | `internal/service/` |
+| infrastructure | `infrastructure/` | `repositories/` | `infra/` | `internal/repository/` |
+| entry | `adapter/in/` | `routes/` | `api/` | `internal/handler/` |
+| config | `config/` | `config/` | `core/` | `internal/config/` |

--- a/skills/context-engineering/references/claude-md-policy-template.md
+++ b/skills/context-engineering/references/claude-md-policy-template.md
@@ -1,7 +1,6 @@
-# CLAUDE.md 정책 템플릿
+# CLAUDE.md Policy Template
 
-> Phase 2 산출물. 이 템플릿을 기반으로 `{CODE_PATH}/CLAUDE.md`를 작성한다.
-> 목표 줄 수: 100~150줄. 초과 항목은 별도 문서로 분리.
+> Phase 2 artifact. Use this template to write `{CODE_PATH}/CLAUDE.md`. Target length: 100~150 lines. Move overflows to separate documents.
 
 ---
 
@@ -10,75 +9,75 @@
 
 This file provides guidance to Claude Code when working with code in this repository.
 
-> {프로젝트 한 줄 설명 — 무엇을 하는 서비스인가}
+> {one-line description}
 
-## 아키텍처
+## Architecture
 
-**설계 근거 (SoC + Cohesion/Coupling)**: 같은 이유로 변경되는 코드는 같이, 다른 이유로 변경되는 코드는 분리. 하나의 모듈은 하나의 관심사만.
+**Design rationale (SoC + Cohesion/Coupling)**: Code that changes for the same reason stays together; code that changes for different reasons is separated. One module, one concern.
 
-**레이어 구조 (Ports & Adapters + DDD)**
+**Layer structure (Ports & Adapters + DDD)**
 
-| 레이어 | 폴더 | Ports & Adapters | 책임 (SRP) | 의존 규칙 (DIP) | DDD 개념 |
-|--------|------|-----------------|-----------|----------------|---------|
-| 도메인 | `{경로}` | — (순수 도메인) | 비즈니스 규칙·불변식 | 외부 의존 없음 | Entity, Value Object, Aggregate, Repository 포트 |
-| 애플리케이션 | `{경로}` | — (Use Case) | 유스케이스 조율 (CQS 적용) | 도메인만 | Command Handler, Query Handler |
-| 인프라 | `{경로}` | Driven Adapter (Secondary) | 외부 시스템 구현체 | 도메인 포트 역전(DIP) | Repository 구현, API Adapter |
-| 진입점 | `{경로}` | Driving Adapter (Primary) | 입력 수신·변환 | 애플리케이션만 | Controller, Consumer |
-| 설정 | `{경로}` | — | 의존성 조립 | 전 레이어 | DI 설정 |
+| Layer | Folder | Ports & Adapters | Responsibility (SRP) | Dependency rule (DIP) | DDD concept |
+|-------|--------|-----------------|---------------------|----------------------|-------------|
+| domain | `{path}` | — (pure domain) | Business rules & invariants | No external dependencies | Entity, Value Object, Aggregate, Repository port |
+| application | `{path}` | — (Use Case) | Use case orchestration (CQS applied) | Domain only | Command Handler, Query Handler |
+| infrastructure | `{path}` | Driven Adapter (Secondary) | External system implementations | Domain port inversion (DIP) | Repository impl, API Adapter |
+| entry | `{path}` | Driving Adapter (Primary) | Input reception & transformation | Application only | Controller, Consumer |
+| config | `{path}` | — | Dependency assembly | All layers | DI configuration |
 
-의존 방향: `진입점(Primary) → 애플리케이션 → 도메인 ← 인프라(Secondary)` (역방향 금지)
+Dependency direction: `entry -> application -> domain <- infrastructure` (reverse forbidden)
 
-**책임 할당 (GRASP Information Expert)**: 책임은 그 정보를 가진 객체에. 계산 로직은 데이터를 가진 도메인 객체에 두고 Service로 위임하지 않는다.
+**Responsibility assignment (GRASP Information Expert)**: Responsibility belongs to the object that holds the information. Calculation logic lives in the domain object that owns the data — do not delegate to Service.
 
-**레이어 경계 규칙 (OCP)**: 외부 API 교체 → Secondary Adapter만 수정. 새 유스케이스 → 애플리케이션 확장, 기존 닫힘.
+**Layer boundary rules (OCP)**: Replace external API → modify Secondary Adapter only. New use case → extend application, existing closed.
 
-## 빌드 & 테스트
+## Build & Test
 
 \`\`\`bash
-# 전체 빌드
+# full build
 {BUILD_CMD}
 
-# 단위 테스트
+# unit tests
 {TEST_CMD}
 
-# 특정 모듈 테스트
+# specific module test
 {MODULE_TEST_CMD}
 
-# 서버 실행
+# run server
 {RUN_CMD}
 \`\`\`
 
-## 포트 / 엔드포인트
+## Ports / Endpoints
 
-| 포트 | 프로토콜 | 용도 |
-|------|---------|------|
-| {포트} | {TCP/HTTP} | {용도} |
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| {port} | {TCP/HTTP} | {purpose} |
 
-## 핵심 제약
+## Core Constraints
 
-{Phase 1 TC/BL 중 개발에 직접 영향을 주는 항목만 — 최대 5개}
+{Only items from Phase 1 TC/BL that directly affect development — 5 max}
 
-- TC-1: {제약}
-- BL-1: {규칙}
+- TC-1: {constraint}
+- BL-1: {rule}
 
 ## Non-obvious Gotchas
 
-> 코드만 봐서는 알 수 없는 함정. 새 팀원이 반드시 알아야 할 것만.
+> Traps that can't be seen from code alone. Only what a new team member must know.
 
-- {함정 1}: {설명}
-- {함정 2}: {설명}
+- {gotcha 1}: {description}
+- {gotcha 2}: {description}
 
-## 참고 문서
+## References
 
-- [{문서명}]({경로}): {한 줄 설명}
+- [{document name}]({path}): {one-line description}
 ```
 
 ---
 
-## 작성 기준
+## Writing Guidelines
 
-1. **WHAT/WHY/HOW**: 무엇을(아키텍처), 왜(설계 의도), 어떻게(명령어)
-2. **줄 수 제한**: 프로젝트 레벨 100~150줄, 모듈 레벨 60~100줄
-3. **초과 시**: 별도 `docs/WORKFLOW_*.md`로 분리하고 링크만 유지
-4. **gotchas 우선**: 코드에서 읽히는 내용은 쓰지 않는다. 함정만.
-5. **명령어 검증**: 실제 실행해서 동작 확인 후 기록
+1. **WHAT/WHY/HOW**: what (architecture), why (design intent), how (commands)
+2. **Line limit**: project level 100~150 lines, module level 60~100 lines
+3. **When over limit**: split to separate `docs/WORKFLOW_*.md` and keep only the link
+4. **Gotchas first**: do not write what can be read from code. Traps only.
+5. **Command verification**: record only after actually running and confirming it works

--- a/skills/context-engineering/references/knowledge-base-template.md
+++ b/skills/context-engineering/references/knowledge-base-template.md
@@ -1,55 +1,55 @@
 # Knowledge Base — {PROJECT_NAME}
 
-> Phase 1 산출물. AI가 이 프로젝트의 도메인을 이해하기 위한 지식 베이스.
+> Phase 1 artifact. Knowledge base for AI to understand this project's domain.
 
 ---
 
-## 도메인 용어 (Glossary)
+## Domain Glossary
 
-| 용어 | 정의 | 출처 |
-|------|------|------|
-| {용어} | {한 줄 정의} | {문서명} |
-
----
-
-## 제약조건 레지스트리
-
-| ID | 분류 | 설명 | 영향 | 우선순위 |
-|----|------|------|------|---------|
-| TC-1 | 기술 | | | High |
-| BL-1 | 비즈니스 | | | Medium |
-| OC-1 | 조직 | | | Low |
-
-**분류 기준**
-- `TC` (Technical Constraint): 기술 스택, 버전, 프로토콜 제약
-- `BL` (Business Logic): 비즈니스 규칙, 계산 방식, 허용 범위
-- `OC` (Organizational Constraint): 일정, 외부 의존성, 접근 제한
+| Term | Definition | Source |
+|------|-----------|--------|
+| {term} | {one-line definition} | {document name} |
 
 ---
 
-## 참조 문서 매니페스트
+## Constraint Registry
 
-| 경로 | 유형 | 요약 | 갱신일 |
-|------|------|------|--------|
-| {경로} | spec | {한 줄 요약} | {YYYY-MM-DD} |
-| {경로} | api-guide | {한 줄 요약} | {YYYY-MM-DD} |
-| {경로} | meeting | {한 줄 요약} | {YYYY-MM-DD} |
+| ID | Category | Description | Impact | Priority |
+|----|----------|-------------|--------|---------|
+| TC-1 | Technical | | | High |
+| BL-1 | Business | | | Medium |
+| OC-1 | Organizational | | | Low |
 
----
-
-## 기술 스택
-
-| 기술 | 버전 | 용도 |
-|------|------|------|
-| {언어} | {버전} | |
-| {프레임워크} | {버전} | |
-| {외부 라이브러리} | {버전} | |
+**Category reference**
+- `TC` (Technical Constraint): tech stack, version, protocol constraints
+- `BL` (Business Logic): business rules, calculation methods, allowed ranges
+- `OC` (Organizational Constraint): schedule, external dependencies, access restrictions
 
 ---
 
-## 기존 코드 패턴 (있을 경우)
+## Reference Document Manifest
 
-- **패키지 구조**: 
-- **주요 패턴**: 
-- **테스트 전략**: 
-- **네이밍 컨벤션**: 
+| Path | Type | Summary | Updated |
+|------|------|---------|---------|
+| {path} | spec | {one line} | {YYYY-MM-DD} |
+| {path} | api-guide | {one line} | {YYYY-MM-DD} |
+| {path} | meeting | {one line} | {YYYY-MM-DD} |
+
+---
+
+## Tech Stack
+
+| Technology | Version | Purpose |
+|------------|---------|---------|
+| {language} | {version} | |
+| {framework} | {version} | |
+| {external library} | {version} | |
+
+---
+
+## Existing Code Patterns (if applicable)
+
+- **Package structure**: 
+- **Key patterns**: 
+- **Test strategy**: 
+- **Naming conventions**: 

--- a/skills/context-engineering/references/phase-checklist.md
+++ b/skills/context-engineering/references/phase-checklist.md
@@ -1,106 +1,106 @@
-# Context Engineering 4단계 체크리스트
+# Context Engineering 4-Phase Checklist
 
-새 프로젝트 시작 시 이 파일을 복사해서 사용한다.
+Copy this file when starting a new project.
 
 ---
 
-## 프로젝트 정보
+## Project Info
 
-- **프로젝트**: 
-- **코드 경로**: 
-- **출력 경로**: 
-- **기술 스택**: 
-- **시작일**: 
+- **Project**: 
+- **Code path**: 
+- **Output path**: 
+- **Tech stack**: 
+- **Start date**: 
 
 ---
 
 ## Step 0: Context Gathering
 
-- [ ] 요구사항 탐색 — 무엇을/왜/알려진 제약 확인
-- [ ] 요구사항 요약 사용자 확인 (HARD-GATE 통과)
-- [ ] 기술 파라미터 수집 (PROJECT_NAME, CODE_PATH, TECH_STACK 등)
-- [ ] 파라미터 최종 요약 사용자 확인
+- [ ] Requirements exploration — confirm What / Why / known constraints
+- [ ] Requirements summary user confirmation (HARD-GATE passed)
+- [ ] Technical parameters collected (PROJECT_NAME, CODE_PATH, TECH_STACK, etc.)
+- [ ] Final parameter summary user confirmation
 
 ## Phase 1: Knowledge Base
 
-- [ ] Context Assessment — 시나리오 판별 (A/B/C/D) + 사용자 확인
-- [ ] Source Scan 실행 (시나리오에 따라 조건부)
-  - [ ] A: Step 0 대화에서 도메인 개념 추출
-  - [ ] B: 스펙 문서 Explore 에이전트 병렬 탐색
-  - [ ] C: 코드베이스 스캔 (패키지 구조, 패턴, 테스트 전략)
-  - [ ] D: B + C 병렬 실행
-- [ ] 도메인 용어 Glossary 작성 (최소 5개)
-- [ ] 제약조건 레지스트리 작성 (TC/BL/OC 분류)
-- [ ] 참조 문서 매니페스트 작성 (시나리오 B/C/D)
-- [ ] `knowledge-base.md` 저장 (시나리오 A는 "초안" 표시)
-- [ ] **자체 평가 수행** (일반 모드) — 게이트 메시지와 함께 출력
+- [ ] Context Assessment — scenario detection (A/B/C/D) + user confirmation
+- [ ] Source Scan complete (conditional on scenario)
+  - [ ] A: Extract domain concepts from Step 0 conversation
+  - [ ] B: Explore sub-agent parallel scan of spec documents
+  - [ ] C: Codebase scan (package structure, patterns, test strategy)
+  - [ ] D: B + C run in parallel
+- [ ] Domain Glossary written (minimum 5 terms)
+- [ ] Constraint Registry written (TC/BL/OC categories)
+- [ ] Reference Document Manifest written (scenarios B/C/D)
+- [ ] `knowledge-base.md` saved (Scenario A marked as "Draft")
+- [ ] **Self-Assessment performed** (normal mode) — output with gate message
 
 ## Phase 2: Policy (CLAUDE.md)
 
-- [ ] CLAUDE.md 레벨 결정 (프로젝트 / 모듈)
-- [ ] 아키텍처 규칙 정의 (레이어 분리, 패턴 제약)
-- [ ] 코딩 컨벤션 문서화 (네이밍, 테스트 패턴)
-- [ ] 빌드/테스트 명령어 정리
-- [ ] Non-obvious gotchas 기록
-- [ ] 150줄 초과 항목은 별도 문서 분리 + 링크
-- [ ] `{CODE_PATH}/CLAUDE.md` 저장
-- [ ] **자체 평가 수행** (일반 모드) — 게이트 메시지와 함께 출력
+- [ ] CLAUDE.md level decided (project / module)
+- [ ] Architecture rules defined (layer separation, pattern constraints)
+- [ ] Coding conventions documented (naming, test patterns)
+- [ ] Build & Test commands verified
+- [ ] Non-obvious gotchas recorded
+- [ ] Items exceeding 150 lines split to separate document + linked
+- [ ] `{CODE_PATH}/CLAUDE.md` saved
+- [ ] **Self-Assessment performed** (normal mode) — output with gate message
 
 ## Phase 3: Spec
 
-- [ ] 설계 결정 (D-*) — 대안/선택/근거 포함
-- [ ] 패키지/모듈 구조 확정
-- [ ] **요구사항 추적 테이블 작성** — REQ-ID → PRD 기능 → 구현 항목
-- [ ] **자체 평가 수행** — Readiness Gate 출력 전
-- [ ] `spec.md` 저장
+- [ ] Architecture decision rationale complete (D-*) — alternatives / choice / rationale included
+- [ ] Package/module structure finalized
+- [ ] **Requirements traceability table written** — REQ-ID → PRD feature → implementation item
+- [ ] **Self-Assessment performed** — before Readiness Gate output
+- [ ] `spec.md` saved
 
 ## Phase 4: Implementation
 
-- [ ] 모듈별 스켈레톤 생성
-- [ ] 핵심 도메인 객체 구현
-- [ ] 어댑터 구현
-- [ ] 테스트 작성 + 통과
-- [ ] 피드백 루프 반영 (발견 내용 → 해당 단계 갱신)
-  - [ ] 도메인/용어 오류 → Phase 1 `knowledge-base.md` 갱신
-  - [ ] AI 행동 규칙 변경 → Phase 2 `CLAUDE.md` 갱신
-  - [ ] 아키텍처·설계 변경 → Phase 3 `spec.md` 갱신
-- [ ] **요구사항 추적 상태 갱신** — 완료된 REQ-ID → "구현 완료"
-- [ ] 아키텍처 문서 작성
-- [ ] 온보딩 가이드 작성
-- [ ] **구현 회고 수행** — 요구사항 달성 / 프로세스 회고 / 문서 최종 상태
+- [ ] Per-module skeleton generated
+- [ ] Core domain objects implemented
+- [ ] Adapters implemented
+- [ ] Tests written + passing
+- [ ] Feedback loop applied (findings → update relevant phase)
+  - [ ] Domain/term error → Phase 1 `knowledge-base.md` updated
+  - [ ] AI behavior rule change → Phase 2 `CLAUDE.md` updated
+  - [ ] Architecture/design change → Phase 3 `spec.md` updated
+- [ ] **Requirements traceability table updated** — completed REQ-IDs marked as "implemented"
+- [ ] Architecture documentation written
+- [ ] Onboarding guide written
+- [ ] **Implementation Retrospective completed** — requirements achievement / process retrospective / final document state
 
 ---
 
-## 산출물 자체 평가 기준
+## Artifact Self-Assessment Criteria
 
-Phase 게이트 직전, 일반 모드에서만 수행. 형식:
+Performed immediately before the phase gate, in normal mode only. Format:
 
 ```
-| 항목 | 상태 | 조치 |
-|------|------|------|
-| {기준} | OK / {갭 설명} | — / {구체적 조치} |
+| Item | Status | Action |
+|------|--------|--------|
+| {criterion} | OK / {gap description} | — / {specific action} |
 ```
 
 **Phase 1 (Knowledge Base)**
 
-| 기준 | 충족 조건 | 미충족 시 조치 |
-|------|---------|------------|
-| 용어 충분성 | Glossary 5개 이상, 핵심 도메인 개념 누락 없음 | Source Scan 재수행 또는 Step 0 대화 보완 |
-| 제약 분류 | TC/BL/OC 중 최소 2개 분류 사용 | 제약 레지스트리 항목 보강 |
-| 출처 명시 | 모든 용어에 출처(문서명/대화) 기재 | 출처 불명 항목 보완 |
+| Criterion | Met condition | Action if unmet |
+|-----------|--------------|-----------------|
+| Term sufficiency | Glossary 5+ terms, no key domain concepts missing | Re-run Source Scan or supplement Step 0 conversation |
+| Constraint categories | At least 2 of TC/BL/OC categories used | Expand constraint registry entries |
+| Source attribution | All terms have source (document name / conversation) recorded | Supplement items missing source |
 
 **Phase 2 (CLAUDE.md)**
 
-| 기준 | 충족 조건 | 미충족 시 조치 |
-|------|---------|------------|
-| 빌드 명령어 검증 | BUILD_CMD, TEST_CMD 실행 확인 완료 | 빌드 파일 재확인 후 갱신 |
-| High 제약 반영 | Phase 1 High 우선순위 제약이 핵심 제약 섹션에 포함 | 핵심 제약 섹션 보완 |
-| KB 링크 존재 | 참고 문서 섹션에 `knowledge-base.md` 링크 있음 | 참고 문서 섹션에 링크 추가 |
+| Criterion | Met condition | Action if unmet |
+|-----------|--------------|-----------------|
+| Build command verified | BUILD_CMD, TEST_CMD execution confirmed | Re-check build files and update |
+| High constraints reflected | Phase 1 High-priority constraints included in Core Constraints section | Supplement Core Constraints section |
+| KB link exists | `knowledge-base.md` link present in References section | Add link to References section |
 
 **Phase 3 (Spec)**
 
-| 기준 | 충족 조건 | 미충족 시 조치 |
-|------|---------|------------|
-| 결정 근거 완전성 | 모든 아키텍처 결정에 대안과 근거 기재 | 미기재 결정 항목 보완 |
-| 구현 순서 의존관계 | 구현 계획에 의존 관계와 완료 기준 기재 | 구현 계획 항목 보완 |
-| REQ 커버리지 | 모든 REQ-ID가 구현 계획에 매핑됨 | 요구사항 추적 테이블 보완 |
+| Criterion | Met condition | Action if unmet |
+|-----------|--------------|-----------------|
+| Decision rationale completeness | All architecture decisions include alternatives and rationale | Supplement missing decision entries |
+| Implementation plan dependencies mapped | Implementation plan includes dependency relationships and done criteria | Supplement implementation plan entries |
+| REQ coverage verified | All REQ-IDs mapped to implementation plan items | Supplement requirements traceability table |

--- a/skills/context-engineering/references/spec-template.md
+++ b/skills/context-engineering/references/spec-template.md
@@ -1,50 +1,49 @@
 # SPEC — {PROJECT_NAME}
 
-> Phase 3 산출물. 어떻게 만들지 기술적으로 정의한다.
+> Phase 3 artifact. Technical definition of how to build it.
 
 ---
 
-## 아키텍처 결정
+## Architecture Decisions
 
-| 결정 사항 | 고려한 대안 | 선택 | 근거 |
+| Decision | Alternatives | Choice | Rationale |
 |---------|-----------|------|------|
-| {무엇을 결정했나} | {대안1}, {대안2} | {선택한 것} | {이유} |
+| {what was decided} | {alt1}, {alt2} | {chosen} | {reason} |
 
 ---
 
-## 패키지 구조
+## Package Structure
 
-의존 방향: `진입점 → 애플리케이션 → 도메인 ← 인프라` (역방향 금지)
+Dependency direction: `entry -> application -> domain <- infrastructure` (reverse forbidden)
 
 ```
-{레이어}: {폴더 경로}  ← {담당 역할}
+{layer}: {folder path}  ← {responsibility}
 ```
 
-> 원칙·레이어 정의·언어별 폴더명 → [architecture-principles.md](architecture-principles.md)
+> Principles, layer definitions, language-specific folder names → [references/architecture-principles.md](references/architecture-principles.md)
 
 ---
 
-## 데이터 흐름
+## Data Flow
 
 ```
-{입력} → {컴포넌트A} → {컴포넌트B} → {출력}
+{input} → {ComponentA} → {ComponentB} → {output}
 ```
 
 ---
 
-## 구현 계획
+## Implementation Plan
 
-| 순서 | 구현 항목 | REQ | 의존 | 완료 기준 |
+| # | Item | REQ | Depends | Done Criteria |
 |------|---------|-----|------|---------|
-| 1 | {첫 번째 구현 단위} | REQ-1 | — | {검증 가능한 기준} |
+| 1 | {first implementation unit} | REQ-1 | — | {verifiable criterion} |
 
 ---
 
-## 요구사항 추적
+## Requirements Traceability
 
-| REQ-ID | 요구사항 | PRD 기능 | 구현 항목 | 상태 |
+| REQ-ID | Requirement | PRD Feature | Implementation Item | Status |
 |--------|---------|---------|---------|------|
-| REQ-1 | {무엇} | {기능명} | 구현 계획 #1 | 미구현 |
-| REQ-2 | {왜/목적} | {기능명} | 구현 계획 #N | 미구현 |
-| REQ-3 | {제약} | {기능명 또는 "비기능"} | 구현 계획 #N | 미구현 |
-
+| REQ-1 | {what} | {feature} | Implementation Plan #1 | not implemented |
+| REQ-2 | {why} | {feature} | Implementation Plan #N | not implemented |
+| REQ-3 | {constraint} | {non-func/feature} | Implementation Plan #N | not implemented |


### PR DESCRIPTION
## Summary
Translates all remaining Korean content to English to prepare the plugin for public distribution.

## Files Changed
- `.claude-plugin/plugin.json`, `marketplace.json` — description fields
- `skills/context-engineering/references/` — all 5 template files
- `README.md`, `CLAUDE.md` — user-facing documentation
- `docs/context-engineering-cycle.html` — UI labels, JS data objects, SVG text

## Notes
- The 5 SKILL.md files were already in English and required no changes
- All translations align with terminology already in the SKILL.md files (source of truth)
- Internal dated design docs (`docs/2026-04-25-*`) are excluded

Closes #89