### PR TITLE
feat: add ke universal knowledge engine (v2.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "context-engineering",
-  "version": "1.0.0",
-  "description": "4-phase Context Engineering workflow for developing complex services with AI tools: domain knowledge collection → Policy (CLAUDE.md) → implementation Spec → step-by-step implementation",
+  "version": "2.0.0",
+  "description": "Context Engineering plugin: universal knowledge engine (/ke) for accumulating and querying knowledge across any domain, plus 4-phase service development workflow (/context-engineering)",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -16,6 +16,11 @@
     "claude-md",
     "knowledge-base",
     "spec",
-    "workflow"
+    "workflow",
+    "ke",
+    "knowledge-engine",
+    "ingest",
+    "query",
+    "universal"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .omx/
 .claude/
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,15 @@ No source code. **Pure markdown** Claude Code plugin:
 - `skills/valid/SKILL.md` — sub-skill: Readiness Gate validation
 - `skills/impl/SKILL.md` — sub-skill: Phase 4 (implementation)
 
+## ke Skill Structure
+
+New in v2.0. Universal knowledge engine, domain-agnostic:
+- `skills/ke/SKILL.md` — main 7-phase engine + auto mode detection (`/ke`)
+- `skills/ke/references/entry-template.md` — knowledge entry format template
+- `skills/ke/references/index-template.md` — index.md format template
+- `skills/ingest/SKILL.md` — direct ingest entry (`/ke:ingest`)
+- `skills/query/SKILL.md` — direct query entry (`/ke:query`)
+
 ## Skill Modification Guidelines
 
 1. **Variable consistency**: only reference variables defined in Step 0 (e.g., `{OUTPUT_PATH}`) in later phases
@@ -24,3 +33,14 @@ No source code. **Pure markdown** Claude Code plugin:
 ## Verification
 
 After modifying a skill, run `/context-engineering @<path>` in a real project to confirm Step 0 parameter collection works correctly.
+
+## ke Design Invariants
+
+These rules must hold for the ke skill and sub-skills:
+
+1. **Mode detection**: `/ke` auto-detects Ingest vs. Query from input signals. Never ask the user which mode unless genuinely ambiguous. Ambiguous → 1 question with options 1/2/3.
+2. **KNOWLEDGE_PATH resolution order**: `--kb` arg → `KNOWLEDGE_PATH` env → `./knowledge/index.md` → `~/knowledge/index.md` → ask user.
+3. **Lightweight gates**: Only 2 checkpoints — after Phase 3 (all-duplicate ingest) and after Phase 7 (conflicts). Never gate on anything else.
+4. **Query is read-only**: `/ke:query` and `/ke:ingest`'s Query mode never write files. Only Ingest writes.
+5. **Concept granularity**: One knowledge entry per concept, not per document or session. Large documents are split into multiple entries.
+6. **Index sync**: index.md is updated atomically on every ingest. Re-sort domain tables by date descending on every update.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ These rules must hold for the ke skill and sub-skills:
 
 1. **Mode detection**: `/ke` auto-detects Ingest vs. Query from input signals. Never ask the user which mode unless genuinely ambiguous. Ambiguous → 1 question with options 1/2/3.
 2. **KNOWLEDGE_PATH resolution order**: `--kb` arg → `KNOWLEDGE_PATH` env → `./knowledge/index.md` → `~/knowledge/index.md` → ask user.
-3. **Lightweight gates**: Only 2 checkpoints — after Phase 3 (all-duplicate ingest) and after Phase 7 (conflicts). Never gate on anything else.
+3. **Lightweight gates**: Only 2 checkpoints — after Phase 3 (all-duplicate ingest) and after Phase 7 (conflicts for ingest; confidence footer for query). Never gate on anything else.
 4. **Query is read-only**: `/ke:query` and `/ke:ingest`'s Query mode never write files. Only Ingest writes.
 5. **Concept granularity**: One knowledge entry per concept, not per document or session. Large documents are split into multiple entries.
 6. **Index sync**: index.md is updated atomically on every ingest. Re-sort domain tables by date descending on every update.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 A Claude Code plugin that defines step-by-step **"what to know, how to behave, and what to build"** when developing complex services with AI tools.
 
+## Skills Overview
+
+This plugin provides two independent skill sets:
+
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| **Knowledge Engine** | `/ke`, `/ke:ingest`, `/ke:query` | Accumulate knowledge from any domain, query it to produce any output |
+| **Service Development** | `/context-engineering`, sub-skills | 4-phase workflow for building complex services with AI |
+
 ## What is Context Engineering?
 
 Context Engineering is **the practice of designing what goes into an LLM's context window**. It goes beyond writing a single good prompt — it decides what information to give to AI, when, and in what structure. RAG, memory architecture, token budget management, and system prompt design all fall under this category.
@@ -85,6 +94,37 @@ Each sub-skill auto-detects existing artifacts (knowledge-base.md, CLAUDE.md, pr
 /context-engineering:valid
 /context-engineering:impl @/path/to/project
 ```
+
+## Knowledge Engine (`/ke`)
+
+A universal 7-phase engine for accumulating knowledge and producing AI-powered output. Not tied to software development — works for any domain and any output type.
+
+### Two modes
+
+- **Ingest** — store information systematically into a knowledge base
+- **Query** — use stored knowledge to answer questions or produce output (code, analysis, reports, documents)
+
+### Commands
+
+```
+/ke                    — auto-detect mode from your input
+/ke:ingest             — force ingest mode
+/ke:query              — force query mode
+/ke --kb /path/to/kb   — use a specific knowledge base location
+```
+
+### How it works
+
+Knowledge is stored as plain markdown files — works with any tool (Obsidian, VS Code, GitHub, etc.).
+
+```
+~/knowledge/             ← default location
+  index.md               ← master index (all entries, searchable)
+  {domain}/
+    {entry-slug}.md      ← one concept per file
+```
+
+Each knowledge entry has frontmatter (title, domain, type, source, date, reliability, tags) and structured body sections (Key Facts, Constraints, Decisions, Notes).
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Verify installation:
 ```bash
 claude plugin list
 #   ❯ context-engineering@context-engineering
-#     Version: 1.0.0
+#     Version: 2.0.0
 #     Scope: user
 #     Status: ✔ enabled
 ```

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -123,7 +123,7 @@ If the user declines the split: accept and proceed to Phase 6. Large entries (>1
 
 Write each entry file to `{KNOWLEDGE_PATH}/{domain}/{slug}.md`.
 
-Update `index.md`: add a new row to the correct domain table (or create the table if the domain is new).
+Update `index.md`: add a new row to the correct domain table. If the domain doesn't yet exist in index.md, create a new `## {domain}` section in alphabetical order among domains. Use the standard table header: `| Entry | Type | Date | Reliability | Tags | Summary |`
 
 Output: `Stored: {domain}/{slug}.md` (one line per entry written)
 
@@ -168,7 +168,7 @@ related: [domain/other-entry]
 **Reliability scale**:
 - `high` — direct user statement, official documentation, code in the repository
 - `medium` — secondhand source, older but verified document
-- `low` — inferred behavior, external claim not yet verified
+- `low` — speculative, experimental, or user-reported without verification
 
 Storage path: `{KNOWLEDGE_PATH}/{domain}/{slugified-title}.md`
 
@@ -197,7 +197,7 @@ Index update rules:
 - Update the row when an entry is modified
 - Remove the row when an entry is deleted
 - Regenerate the header counts (`Total entries`, `Domains`) on every update
-- Sort entries within a domain by date descending (newest first)
+- Sort entries within a domain by date descending (newest first). Re-sort the domain table on every update.
 
 ---
 
@@ -205,9 +205,10 @@ Index update rules:
 
 For simple inputs, multiple phases execute in a single step without visible output:
 
-| Scenario | Behavior |
-|----------|----------|
-| Short simple ingest (1–2 sentences, clear domain) | Phases 1–5 execute silently; user sees only Phase 6 confirmation |
-| Large document ingest (1000+ words) | All phases shown with progress markers |
+| Threshold | Behavior |
+|-----------|----------|
+| ≤100 words (or ≤3 sentences) AND single clear domain | Phases 1–5 execute silently; user sees only Phase 6 confirmation |
+| 100–1000 words OR ambiguous domain | Show Phase 1 classification, then Phase 6 confirmation |
+| 1000+ words | Show all phase transitions with progress markers |
 
 Rule: show phase transitions when the input is complex. For simple inputs, phases execute silently and the user sees only the final output.

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: ke:ingest
+description: >
+  Direct entry to Knowledge Engine ingest mode. Store information into a structured knowledge base.
+  Use when you have information to store and don't need mode detection.
+  Keywords: ingest, store, remember, save, knowledge base, note
+allowed-tools: Read, Write, Bash, Grep, Glob
+---
+
+# Knowledge Engine: Ingest Mode (ke:ingest)
+
+Store any information (documents, notes, URLs, facts, decisions) into a structured knowledge base without mode detection. This sub-skill skips query behavior entirely and runs only the ingest-relevant phases of the Knowledge Engine.
+
+---
+
+## Usage
+
+```
+/ke:ingest                      — ingest from next message or stdin
+/ke:ingest "text or file path"  — ingest specific content
+/ke:ingest --kb <path>          — override knowledge base location
+```
+
+---
+
+## KNOWLEDGE_PATH Resolution
+
+The engine needs a root directory for all knowledge entries and the index. Resolution order:
+
+1. `--kb <path>` argument passed to the skill
+2. Environment variable `KNOWLEDGE_PATH`
+3. `./knowledge/index.md` in the current working directory
+4. `~/knowledge/index.md` as the user default
+5. Not found → ask once: "Where should I store knowledge? (default: `~/knowledge/`)"
+
+On first use, if the resolved directory does not exist, create it and write an empty `index.md`.
+
+---
+
+## Ingest Flow (7 Phases)
+
+### Phase 1: Problem Definition
+
+Classify the input:
+- **Domain**: The subject area (e.g., project-name, architecture, legal, process)
+- **Type**: fact | decision | constraint | procedure | reference
+  - `fact` — an observable or reported truth
+  - `decision` — a choice made and its rationale
+  - `constraint` — a limitation, rule, or boundary condition
+  - `procedure` — step-by-step instructions for doing something
+  - `reference` — a pointer to an external source
+- **Importance**: H (must retain long-term), M (useful context), L (ephemeral)
+
+Output: `[Domain: X] [Type: fact/decision/constraint/procedure/reference] [Importance: H/M/L]`
+
+If domain is genuinely unclear, ask: "Which domain fits best? e.g., {list examples}"
+
+---
+
+### Phase 2: Candidate Collection
+
+Read the full input content:
+- If a file path: read the file
+- If a URL: fetch the content
+- If pasted text: use as-is
+
+Output: Full content loaded (internal — shown to user only if debugging is needed)
+
+If input is 10,000+ words: "Store as a single entry or split by section?"
+
+---
+
+### Phase 3: Selection
+
+Filter content. Label each chunk:
+- **Keep**: new, high-value material
+- **Skip**: trivial, redundant, or out-of-scope
+- **Merge**: overlaps an existing entry
+
+Check `index.md` for existing entries in the same domain with similar titles or tags.
+
+Output: Internal — not shown unless complex
+
+**Quality Checkpoint A**: If ALL content is classified as Skip or Merge with no new material:
+
+> "Everything in this input is already stored. Options:
+> (1) Skip — nothing to add
+> (2) Update existing entries with today's date to mark as re-verified"
+
+**Merge heuristic**: Two entries merge if they share >70% semantic overlap AND cover the same narrow concept. Related-but-distinct concepts should remain separate.
+
+If Merge candidates are found: "Entry `domain/slug.md` already covers this. Update it or keep both?"
+
+---
+
+### Phase 4: Structuring
+
+Format each Keep chunk into a standard knowledge entry. Generate a slugified filename.
+
+Output: Structured entry draft (internal)
+
+Entry format rules:
+- Frontmatter fields: `title`, `domain`, `type`, `source`, `date`, `reliability`, `tags`, `related`
+- Body sections: `## Key Facts`, `## Constraints`, `## Decisions`, `## Notes`
+- Omit any empty section entirely
+- Target length: 20–80 lines including frontmatter
+
+---
+
+### Phase 5: Compression
+
+Remove redundant examples. Trim verbose prose to essential facts. Aim for 20–80 lines per entry.
+
+Output: Compressed entry draft (internal)
+
+If entry exceeds 80 lines after compression: "This entry is large. Split into `{title-part-a}` and `{title-part-b}`?"
+
+If the user declines the split: accept and proceed to Phase 6. Large entries (>100 lines) are harder to retrieve but user choice is final.
+
+---
+
+### Phase 6: Execution
+
+Write each entry file to `{KNOWLEDGE_PATH}/{domain}/{slug}.md`.
+
+Update `index.md`: add a new row to the correct domain table (or create the table if the domain is new).
+
+Output: `Stored: {domain}/{slug}.md` (one line per entry written)
+
+---
+
+### Phase 7: Verification
+
+Scan existing entries for semantic conflicts with the new entry. Add `related` cross-references where appropriate. Verify `index.md` row count matches files on disk.
+
+Output: Silent on success.
+
+**On conflict**: "Conflict with `domain/existing.md`: [description]. Keep new entry, update existing, or discard?"
+
+**Semantic conflict** = new entry contradicts or supersedes a stored fact (e.g., different values for the same factual claim). Minor thematic overlap does NOT trigger a conflict.
+
+---
+
+## Knowledge Entry Format
+
+```markdown
+---
+title: {descriptive title}
+domain: {domain-slug}
+type: fact | decision | constraint | procedure | reference
+source: user | document:filename | url:https://...
+date: {YYYY-MM-DD}
+reliability: high | medium | low
+tags: [tag1, tag2]
+related: [domain/other-entry]
+---
+
+# {Title}
+
+> {one-line summary}
+
+## Key Facts
+## Constraints
+## Decisions
+## Notes
+```
+
+**Reliability scale**:
+- `high` — direct user statement, official documentation, code in the repository
+- `medium` — secondhand source, older but verified document
+- `low` — inferred behavior, external claim not yet verified
+
+Storage path: `{KNOWLEDGE_PATH}/{domain}/{slugified-title}.md`
+
+**Granularity**: one entry per **concept** — not per document, session, or conversation turn. If one document contains three distinct concepts, create three entries.
+
+Empty sections are omitted entirely from the written file.
+
+---
+
+## Index Format
+
+```markdown
+# Knowledge Index
+
+> Last updated: YYYY-MM-DD | Total entries: N | Domains: domain-a, domain-b
+
+## {domain}
+
+| Entry | Type | Date | Reliability | Tags | Summary |
+|-------|------|------|-------------|------|---------|
+| [title](domain/slug.md) | fact | YYYY-MM-DD | high | tag1, tag2 | one-line summary |
+```
+
+Index update rules:
+- Add a new row when an entry is created
+- Update the row when an entry is modified
+- Remove the row when an entry is deleted
+- Regenerate the header counts (`Total entries`, `Domains`) on every update
+- Sort entries within a domain by date descending (newest first)
+
+---
+
+## Phase Skipping
+
+For simple inputs, multiple phases execute in a single step without visible output:
+
+| Scenario | Behavior |
+|----------|----------|
+| Short simple ingest (1–2 sentences, clear domain) | Phases 1–5 execute silently; user sees only Phase 6 confirmation |
+| Large document ingest (1000+ words) | All phases shown with progress markers |
+
+Rule: show phase transitions when the input is complex. For simple inputs, phases execute silently and the user sees only the final output.

--- a/skills/ke/SKILL.md
+++ b/skills/ke/SKILL.md
@@ -147,7 +147,7 @@ Entry format rules:
 
 | | Ingest | Query |
 |---|---|---|
-| **Action** | Write each entry file to `{KNOWLEDGE_PATH}/{domain}/{slug}.md`. Update `index.md`: add a new row to the correct domain table (or create the table if the domain is new). | Generate the answer in the requested output format using the assembled context. Honor the format determined in Phase 1. |
+| **Action** | Write each entry file to `{KNOWLEDGE_PATH}/{domain}/{slug}.md`. Update `index.md`: add a new row to the correct domain table. If the domain doesn't yet exist in index.md, create a new `## {domain}` section in alphabetical order among domains. Use the table header: `\| Entry \| Type \| Date \| Reliability \| Tags \| Summary \|` | Generate the answer in the requested output format using the assembled context. Honor the format determined in Phase 1. |
 | **Output** | `Stored: {domain}/{slug}.md` (one line per entry written) | The answer — prose, list, table, code block, analysis, or full document, as appropriate |
 | **Decision** | None | None |
 
@@ -178,7 +178,7 @@ For simple inputs, multiple phases execute in a single step without visible outp
 
 | Scenario | Behavior |
 |----------|----------|
-| Short simple ingest (1–2 sentences, clear domain) | Phases 1–5 execute silently; user sees only Phase 6 confirmation |
+| ≤100 words (or ≤3 sentences) AND single clear domain | Phases 1–5 execute silently; user sees only Phase 6 confirmation |
 | Query with 1–2 matching index entries | Phases 3 and 5 execute silently |
 | Large document ingest (1000+ words) | All phases shown with progress markers |
 | Multi-domain or complex query | All phases shown with progress markers |
@@ -200,7 +200,9 @@ If ALL content is classified as Skip or Merge with no new material:
 **Checkpoint B — After Phase 7 (both modes)**
 
 - Ingest: surface any unresolved conflicts before closing. If none, complete silently.
-- Query: the confidence footer is always shown. If confidence is Low, add: "Consider ingesting more information on this topic before relying on this answer."
+- Query: the confidence footer is always shown.
+  - M (Medium): footer + "Consider ingesting more recent information to improve accuracy."
+  - L (Low): footer + "⚠ Answer relies primarily on general knowledge. Consider ingesting relevant knowledge."
 
 The engine flows without interruption except at these two points and the single-question decision points within each phase.
 
@@ -218,7 +220,7 @@ date: {YYYY-MM-DD}
 reliability: high | medium | low
   # high — direct user statement, official documentation, code in the repository
   # medium — secondhand source, older but verified document
-  # low — inferred behavior, external claim not yet verified
+  # low — speculative, experimental, or user-reported without verification
 tags: [tag1, tag2]
 related: [domain/other-entry]
 ---

--- a/skills/ke/SKILL.md
+++ b/skills/ke/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: ke
+description: >
+  7-phase Context Engineering knowledge engine.
+  Ingest information into a structured knowledge base or query it to produce results.
+  Universal — not tied to any specific domain or output type.
+  Keywords: knowledge, context engineering, ingest, query, knowledge base, store, remember, recall
+allowed-tools: Read, Write, Bash, Grep, Glob
+---
+
+# Knowledge Engine (ke)
+
+A universal 7-phase knowledge engine. It operates in two modes:
+
+- **Ingest**: Accepts any information (text, documents, URLs, notes) and stores it as structured entries in a knowledge base.
+- **Query**: Accepts any question or output request and produces a result by drawing on stored knowledge.
+
+Both modes run the same 7-phase engine. Phase behavior varies by mode.
+
+---
+
+## Usage
+
+```
+/ke                          — auto-detect mode, full 7-phase engine
+/ke "some text or question"  — auto-detect mode from the input
+/ke:ingest                   — force ingest mode
+/ke:query                    — force query mode
+```
+
+Optional argument: `--kb <path>` to override the knowledge base location.
+
+---
+
+## KNOWLEDGE_PATH Resolution
+
+The engine needs a root directory for all knowledge entries and the index. Resolution order:
+
+1. `--kb <path>` argument passed to the skill
+2. Environment variable `KNOWLEDGE_PATH`
+3. `./knowledge/index.md` in the current working directory
+4. `~/knowledge/index.md` as the user default
+5. Not found → ask once: "Where should I store knowledge? (default: `~/knowledge/`)"
+
+On first use, if the resolved directory does not exist, create it and write an empty `index.md`.
+
+---
+
+## Phase 0: Mode Detection
+
+Before entering the 7-phase engine, auto-detect the operating mode.
+
+**Ingest signals** (any one is sufficient):
+- User provides a document, file path, or URL
+- User says "remember this", "store this", "note that", "save this"
+- Content is longer than the framing question
+- User makes factual statements without asking for anything in return
+
+**Query signals** (any one is sufficient):
+- A question mark is present
+- User requests output: "write me...", "analyze...", "compare...", "summarize..."
+- User references stored knowledge: "based on what I told you...", "what do we know about..."
+
+**Ambiguous**: Ask ONE question — no more:
+
+> "Is this information to store, or a question to answer?
+> (1) Store it  (2) Answer it  (3) Both"
+
+Option 3 (Both) runs Ingest phases 1–7 first, then Query phases 1–7 on the same input.
+
+When mode is forced via `:ingest` or `:query`, skip detection entirely.
+
+---
+
+## The 7-Phase Engine
+
+### Phase 1: Problem Definition (문제 정의)
+
+| | Ingest | Query |
+|---|---|---|
+| **Action** | Classify the input: domain, knowledge type, importance | Rephrase the question precisely; identify relevant domains; determine output format |
+| **Output** | `[Domain: X] [Type: fact/decision/constraint/procedure/reference] [Importance: H/M/L]` | `[Query: rephrased text] [Domains: X, Y] [Format: prose/list/table/code/analysis/document]` |
+| **Decision** | If domain is genuinely unclear, ask: "Which domain fits best? e.g., finance, health, legal, project-X" | If output format is ambiguous, ask: "What format do you need? e.g., prose summary, comparison table, bullet list" |
+
+Type definitions:
+- `fact` — an observable or reported truth
+- `decision` — a choice made and its rationale
+- `constraint` — a limitation, rule, or boundary condition
+- `procedure` — step-by-step instructions for doing something
+- `reference` — a pointer to an external source
+
+Importance scale: H = must retain long-term, M = useful context, L = ephemeral or low-signal.
+
+---
+
+### Phase 2: Candidate Collection (후보 수집)
+
+| | Ingest | Query |
+|---|---|---|
+| **Action** | Read the full input content. If a file path is given, read the file. If a URL, fetch it. If pasted text, use as-is. | Read `index.md`. Find entries whose domain, tags, or summary match the query. Read each candidate entry file. |
+| **Output** | Full content loaded (internal — not shown to user unless debugging) | List of candidates with brief relevance notes: `domain/slug.md — relevant because: ...` |
+| **Decision** | If input is 10,000+ words: "Store as a single entry or split by section?" | If 0 candidates found: report gracefully — "No stored knowledge matches this query. Proceeding with general knowledge only." |
+
+---
+
+### Phase 3: Selection (선택)
+
+| | Ingest | Query |
+|---|---|---|
+| **Action** | Filter content. Label each chunk: **Keep** (new, high-value), **Skip** (trivial, redundant), **Merge** (overlaps an existing entry). Check `index.md` for existing entries in the same domain with similar titles or tags. | Rank candidates by relevance, recency, and reliability. Discard entries with no meaningful bearing on the query. |
+| **Output** | Internal — not shown unless complex | Ranked list of entries to use (internal) |
+| **Decision** | If Merge candidates are found: "Entry `domain/slug.md` already covers this. Update it or keep both?" | If all candidates are low-relevance: note the gap — "Available knowledge is tangential. Answer will rely more on general reasoning." |
+
+---
+
+### Phase 4: Structuring (구조화)
+
+| | Ingest | Query |
+|---|---|---|
+| **Action** | Format each Keep chunk into a standard knowledge entry (see Entry Format below). One entry per concept. Generate a slugified filename. | Organize selected entries and relevant excerpts into a coherent context block for answering. Sequence them logically. |
+| **Output** | Structured entry draft (internal) | Internal context assembled |
+| **Decision** | None — proceed automatically | None — proceed automatically |
+
+Entry format rules:
+- Frontmatter fields: `title`, `domain`, `type`, `source`, `date`, `reliability`, `tags`, `related`
+- Body sections: `## Key Facts`, `## Constraints`, `## Decisions`, `## Notes`
+- Omit any empty section entirely
+- Target length: 20–80 lines including frontmatter
+
+---
+
+### Phase 5: Compression (압축)
+
+| | Ingest | Query |
+|---|---|---|
+| **Action** | Remove redundant examples. Trim verbose prose to essential facts. Aim for 20–80 lines per entry. | Summarize tangential context to fit the context budget. Keep high-relevance excerpts verbatim. |
+| **Output** | Compressed entry draft (internal) | Compressed context (internal) |
+| **Decision** | If entry exceeds 80 lines after compression: "This entry is large. Split into `{title-part-a}` and `{title-part-b}`?" | None — proceed automatically |
+
+---
+
+### Phase 6: Execution (실행)
+
+| | Ingest | Query |
+|---|---|---|
+| **Action** | Write each entry file to `{KNOWLEDGE_PATH}/{domain}/{slug}.md`. Update `index.md`: add a new row to the correct domain table (or create the table if the domain is new). | Generate the answer in the requested output format using the assembled context. Honor the format determined in Phase 1. |
+| **Output** | `Stored: {domain}/{slug}.md` (one line per entry written) | The answer — prose, list, table, code block, analysis, or full document, as appropriate |
+| **Decision** | None | None |
+
+Supported query output formats (non-exhaustive): prose narrative, bullet list, comparison table, code snippet, structured analysis, full document, step-by-step instructions, numbered summary.
+
+---
+
+### Phase 7: Verification (검증)
+
+| | Ingest | Query |
+|---|---|---|
+| **Action** | Scan existing entries for semantic conflicts with the new entry. Add `related` cross-references where appropriate. Verify `index.md` row count matches files on disk. | Check the answer for unsupported claims, internal contradictions, and gaps relative to stored knowledge. |
+| **Output** | Silent on success. Conflict: "Conflict with `domain/existing.md`: [description]. Keep new entry, update existing, or discard?" | Confidence footer appended to answer: `[Confidence: H/M/L] — based on N entries. Gaps: {gap description or "none"}` |
+| **Decision** | On conflict: ask user to resolve (keep new / update existing / discard) | None — gaps are reported in the confidence footer, not as a blocking question |
+
+---
+
+## Phase Skipping
+
+For simple inputs, multiple phases execute in a single step without visible output:
+
+| Scenario | Behavior |
+|----------|----------|
+| Short simple ingest (1–2 sentences, clear domain) | Phases 1–5 execute silently; user sees only Phase 6 confirmation |
+| Query with 1–2 matching index entries | Phases 3 and 5 execute silently |
+| Large document ingest (1000+ words) | All phases shown with progress markers |
+| Multi-domain or complex query | All phases shown with progress markers |
+
+Rule: show phase transitions when the input is complex. For simple inputs, phases execute silently and the user sees only the final output.
+
+---
+
+## Quality Checkpoints
+
+There are exactly **two** checkpoints. No other gates.
+
+**Checkpoint A — After Phase 3 (Ingest only)**
+
+If ALL content is classified as Skip or Merge with no new material:
+
+> "Everything in this input is already stored. Options: (1) Skip — nothing to add. (2) Update existing entries with today's date to mark as re-verified."
+
+**Checkpoint B — After Phase 7 (both modes)**
+
+- Ingest: surface any unresolved conflicts before closing. If none, complete silently.
+- Query: the confidence footer is always shown. If confidence is Low, add: "Consider ingesting more information on this topic before relying on this answer."
+
+The engine flows without interruption except at these two points and the single-question decision points within each phase.
+
+---
+
+## Knowledge Entry Format
+
+```markdown
+---
+title: {descriptive title}
+domain: {domain-slug}
+type: fact | decision | constraint | procedure | reference
+source: user | document:filename | url:https://...
+date: {YYYY-MM-DD}
+reliability: high | medium | low
+tags: [tag1, tag2]
+related: [domain/other-entry]
+---
+
+# {Title}
+
+> {one-line summary}
+
+## Key Facts
+## Constraints
+## Decisions
+## Notes
+```
+
+Storage path: `{KNOWLEDGE_PATH}/{domain}/{slugified-title}.md`
+
+Granularity: one entry per **concept** — not per document, session, or conversation turn. If one document contains three distinct concepts, create three entries.
+
+Empty sections are omitted entirely from the written file.
+
+---
+
+## Index Format
+
+```markdown
+# Knowledge Index
+
+> Last updated: YYYY-MM-DD | Total entries: N | Domains: domain-a, domain-b
+
+## {domain}
+
+| Entry | Type | Date | Reliability | Tags | Summary |
+|-------|------|------|-------------|------|---------|
+| [title](domain/slug.md) | fact | YYYY-MM-DD | high | tag1, tag2 | one-line summary |
+```
+
+Index update rules:
+- Add a new row when an entry is created
+- Update the row when an entry is modified
+- Remove the row when an entry is deleted
+- Regenerate the header counts (`Total entries`, `Domains`) on every update
+- Sort entries within a domain by date descending (newest first)
+
+---
+
+## References
+
+- [Entry Template](references/entry-template.md)
+- [Index Template](references/index-template.md)

--- a/skills/ke/SKILL.md
+++ b/skills/ke/SKILL.md
@@ -79,8 +79,10 @@ When mode is forced via `:ingest` or `:query`, skip detection entirely.
 | | Ingest | Query |
 |---|---|---|
 | **Action** | Classify the input: domain, knowledge type, importance | Rephrase the question precisely; identify relevant domains; determine output format |
-| **Output** | `[Domain: X] [Type: fact/decision/constraint/procedure/reference] [Importance: H/M/L]` | `[Query: rephrased text] [Domains: X, Y] [Format: prose/list/table/code/analysis/document]` |
+| **Output** | `[Domains: X] [Type: fact/decision/constraint/procedure/reference] [Importance: H/M/L]` | `[Query: rephrased text] [Domains: X, Y] [Format: prose/list/table/code/analysis/document]` |
 | **Decision** | If domain is genuinely unclear, ask: "Which domain fits best? e.g., finance, health, legal, project-X" | If output format is ambiguous, ask: "What format do you need? e.g., prose summary, comparison table, bullet list" |
+
+Note (Ingest): An entry belongs to one domain; use the most specific one. If cross-domain, choose primary.
 
 Type definitions:
 - `fact` — an observable or reported truth
@@ -111,6 +113,8 @@ Importance scale: H = must retain long-term, M = useful context, L = ephemeral o
 | **Output** | Internal — not shown unless complex | Ranked list of entries to use (internal) |
 | **Decision** | If Merge candidates are found: "Entry `domain/slug.md` already covers this. Update it or keep both?" | If all candidates are low-relevance: note the gap — "Available knowledge is tangential. Answer will rely more on general reasoning." |
 
+Merge heuristic: Two entries merge if they share >70% semantic overlap AND cover the same narrow concept. Related-but-distinct concepts (e.g., "Python async patterns" vs. "asyncio event loops") should remain separate entries.
+
 ---
 
 ### Phase 4: Structuring (구조화)
@@ -135,7 +139,7 @@ Entry format rules:
 |---|---|---|
 | **Action** | Remove redundant examples. Trim verbose prose to essential facts. Aim for 20–80 lines per entry. | Summarize tangential context to fit the context budget. Keep high-relevance excerpts verbatim. |
 | **Output** | Compressed entry draft (internal) | Compressed context (internal) |
-| **Decision** | If entry exceeds 80 lines after compression: "This entry is large. Split into `{title-part-a}` and `{title-part-b}`?" | None — proceed automatically |
+| **Decision** | If entry exceeds 80 lines after compression: "This entry is large. Split into `{title-part-a}` and `{title-part-b}`?" If the user declines the split: accept and proceed to Phase 6. Large entries (>100 lines) are harder to retrieve but user choice is final. | None — proceed automatically |
 
 ---
 
@@ -158,6 +162,13 @@ Supported query output formats (non-exhaustive): prose narrative, bullet list, c
 | **Action** | Scan existing entries for semantic conflicts with the new entry. Add `related` cross-references where appropriate. Verify `index.md` row count matches files on disk. | Check the answer for unsupported claims, internal contradictions, and gaps relative to stored knowledge. |
 | **Output** | Silent on success. Conflict: "Conflict with `domain/existing.md`: [description]. Keep new entry, update existing, or discard?" | Confidence footer appended to answer: `[Confidence: H/M/L] — based on N entries. Gaps: {gap description or "none"}` |
 | **Decision** | On conflict: ask user to resolve (keep new / update existing / discard) | None — gaps are reported in the confidence footer, not as a blocking question |
+
+Semantic conflict = new entry contradicts or supersedes a stored fact (e.g., different values for the same factual claim). Minor thematic overlap does NOT trigger a conflict.
+
+Confidence levels:
+- High (H): 3+ consistent recent entries; answer is well-grounded
+- Medium (M): 1–2 entries or dated entries; note gaps, answer is reasonable
+- Low (L): 0 relevant entries or contradictory entries; answer relies on general knowledge — always append a warning
 
 ---
 
@@ -205,6 +216,9 @@ type: fact | decision | constraint | procedure | reference
 source: user | document:filename | url:https://...
 date: {YYYY-MM-DD}
 reliability: high | medium | low
+  # high — direct user statement, official documentation, code in the repository
+  # medium — secondhand source, older but verified document
+  # low — inferred behavior, external claim not yet verified
 tags: [tag1, tag2]
 related: [domain/other-entry]
 ---

--- a/skills/ke/references/entry-template.md
+++ b/skills/ke/references/entry-template.md
@@ -44,6 +44,8 @@ tags: ["tag1", "tag2", "concept"]
 related: ["domain/related-entry", "domain/another-entry"]
 ---
 
+# {Title}
+
 > One-line summary of this knowledge entry.
 
 ## Key Facts

--- a/skills/ke/references/entry-template.md
+++ b/skills/ke/references/entry-template.md
@@ -1,0 +1,63 @@
+---
+title: "Example: Knowledge Entry Title"
+domain: "domain-name"
+type: "fact|decision|constraint|procedure|reference"
+source: "user|document:filename|url:https://example.com"
+date: "2026-04-25"
+reliability: "high|medium|low"
+tags: ["tag1", "tag2", "concept"]
+related: ["domain/related-entry", "domain/another-entry"]
+---
+
+> One-line summary of this knowledge entry.
+
+## Key Facts
+
+- Fact 1
+- Fact 2
+- Fact 3
+
+## Constraints
+
+- Constraint 1
+- Constraint 2
+
+## Decisions
+
+- Decision 1 and rationale
+- Decision 2 and rationale
+
+## Notes
+
+- Implementation note
+- Edge case handling
+- Additional context
+
+---
+
+## Usage
+
+**Structure Guidelines:**
+- Keep entries between 20–80 lines total (including frontmatter)
+- Omit empty sections entirely
+- Use bullet lists for facts, constraints, decisions, and notes
+- One entry = one concept or related cluster
+
+**Naming Convention:**
+- Filename: `{domain}/{slugified-title}.md`
+- Example: `database/transaction-isolation-levels.md`
+- Example: `architecture/hexagonal-pattern-principles.md`
+
+**When to Split:**
+- If an entry grows beyond 80 lines, split it into multiple focused entries
+- Link related entries using the `related` field in frontmatter
+
+**Frontmatter Fields:**
+- `title`: Human-readable concept name
+- `domain`: Category (e.g., database, architecture, security, api-design)
+- `type`: fact (observable truth), decision (choice made), constraint (limitation), procedure (how-to steps), reference (link to external source)
+- `source`: Origin (user, document:FILENAME, url:HTTPS_URL)
+- `date`: ISO 8601 (YYYY-MM-DD) when entry was created or last verified
+- `reliability`: Confidence level (high = verified, medium = assumed, low = experimental)
+- `tags`: Searchable keywords (array)
+- `related`: Links to other entries in the KB (array of relative paths)

--- a/skills/ke/references/entry-template.md
+++ b/skills/ke/references/entry-template.md
@@ -1,10 +1,45 @@
+# Template Instructions
+
+This is a template for generating knowledge base entries. **Everything below the `---` line is the actual template structure to fill in.**
+
+## Guidelines for AI Reading This Template
+
+**Structure:**
+- Keep entries between 20–80 lines total (including frontmatter)
+- Omit empty sections entirely
+- Use bullet lists for facts, constraints, decisions, and notes
+- One entry = one concept or related cluster
+
+**Naming Convention:**
+- Filename: `{domain}/{slugified-title}.md`
+- Example: `database/transaction-isolation-levels.md`
+- Example: `architecture/hexagonal-pattern-principles.md`
+
+**Frontmatter field reference:**
+- `title`: Human-readable concept name
+- `domain`: Category (e.g., database, architecture, security, api-design)
+- `type`: entry classification — choose one: `fact` (observable truth), `decision` (choice made), `constraint` (limitation), `procedure` (how-to steps), `reference` (link to external source)
+- `source`: Origin — format as one of: `user`, `document:FILENAME`, `url:HTTPS_URL`
+- `date`: ISO 8601 (YYYY-MM-DD) when entry was created or last verified
+- `reliability`: Confidence level — choose one: `high` (verified), `medium` (assumed), `low` (experimental)
+- `tags`: Searchable keywords (array)
+- `related`: Links to other entries in the KB (array of relative paths, e.g., `["domain/entry-name", "domain/another-entry"]`)
+
+**When to split entries:**
+- If an entry grows beyond 80 lines, split it into multiple focused entries
+- Link related entries using the `related` field in frontmatter
+
+---
+
+## Template: Knowledge Entry
+
 ---
 title: "Example: Knowledge Entry Title"
 domain: "domain-name"
-type: "fact|decision|constraint|procedure|reference"
-source: "user|document:filename|url:https://example.com"
+type: fact
+source: "user"
 date: "2026-04-25"
-reliability: "high|medium|low"
+reliability: "high"
 tags: ["tag1", "tag2", "concept"]
 related: ["domain/related-entry", "domain/another-entry"]
 ---
@@ -32,32 +67,3 @@ related: ["domain/related-entry", "domain/another-entry"]
 - Implementation note
 - Edge case handling
 - Additional context
-
----
-
-## Usage
-
-**Structure Guidelines:**
-- Keep entries between 20–80 lines total (including frontmatter)
-- Omit empty sections entirely
-- Use bullet lists for facts, constraints, decisions, and notes
-- One entry = one concept or related cluster
-
-**Naming Convention:**
-- Filename: `{domain}/{slugified-title}.md`
-- Example: `database/transaction-isolation-levels.md`
-- Example: `architecture/hexagonal-pattern-principles.md`
-
-**When to Split:**
-- If an entry grows beyond 80 lines, split it into multiple focused entries
-- Link related entries using the `related` field in frontmatter
-
-**Frontmatter Fields:**
-- `title`: Human-readable concept name
-- `domain`: Category (e.g., database, architecture, security, api-design)
-- `type`: fact (observable truth), decision (choice made), constraint (limitation), procedure (how-to steps), reference (link to external source)
-- `source`: Origin (user, document:FILENAME, url:HTTPS_URL)
-- `date`: ISO 8601 (YYYY-MM-DD) when entry was created or last verified
-- `reliability`: Confidence level (high = verified, medium = assumed, low = experimental)
-- `tags`: Searchable keywords (array)
-- `related`: Links to other entries in the KB (array of relative paths)

--- a/skills/ke/references/index-template.md
+++ b/skills/ke/references/index-template.md
@@ -1,12 +1,38 @@
-# Knowledge Base Index
+# Template Instructions
 
-**Last updated:** 2026-04-25  
-**Total entries:** 42  
-**Domains:** 6 (architecture, database, api-design, security, infrastructure, patterns)
+This is a template for generating the knowledge base index. The values below are **EXAMPLES** showing the structure — replace them with actual values from your knowledge base.
+
+## Guidelines for AI Reading This Template
+
+**Index generation:**
+- Replace example header titles (Architecture, Database) with actual domain names from your KB
+- Replace example entries with real entries from `knowledge-base/` directory
+- Extract metadata (Title, Type, Date, Reliability, Tags, first line summary) from each entry's frontmatter and content
+
+**Index updates:**
+- Regenerate completely when new entries are added
+- Sort entries by domain, then by filename
+- Ensure the count matches actual entries on disk
+
+**Index structure:**
+- One section per domain (alphabetical or by frequency)
+- Table columns: Entry | Type | Date | Reliability | Tags | Summary
+- Summary = first content line (the `>` blockquote) from each entry file
+- Links = relative paths from index location to entry files
 
 ---
 
-## Architecture
+## Template: Knowledge Base Index
+
+# Knowledge Base Index
+
+**Last updated:** 2026-04-25 (example — replace with current date)  
+**Total entries:** 42 (example — replace with actual count)  
+**Domains:** 6 (example — list actual domains: architecture, database, api-design, security, infrastructure, patterns)
+
+---
+
+## Architecture (example domain)
 
 | Entry | Type | Date | Reliability | Tags | Summary |
 |-------|------|------|-------------|------|---------|
@@ -14,30 +40,12 @@
 | [Service Boundary Rules](./architecture/service-boundary-rules.md) | constraint | 2026-04-18 | high | architecture, microservices | Defines when to split services and how to model dependencies |
 | [Event-Driven Communication](./architecture/event-driven-communication.md) | procedure | 2026-04-15 | medium | architecture, messaging, async | Step-by-step guide for implementing event sourcing patterns |
 
-## Database
+## Database (example domain)
 
 | Entry | Type | Date | Reliability | Tags | Summary |
 |-------|------|------|-------------|------|---------|
 | [Transaction Isolation Levels](./database/transaction-isolation-levels.md) | fact | 2026-04-22 | high | database, transactions, concurrency | Overview of ACID properties and isolation level tradeoffs |
 | [Index Strategy](./database/index-strategy.md) | decision | 2026-04-10 | high | database, performance, indexing | Rules for when and how to index columns |
-
----
-
-## Index Management
-
-**Updated atomically on every ingest:** When new knowledge entries are added to the knowledge base, the index is regenerated completely. This ensures consistency between the index table and the actual files on disk.
-
-**Used for candidate search on every query:** The index table enables fast filtering by domain, type, date, and reliability before fetching full entry contents. Search logic:
-1. Filter candidates by domain and tags
-2. Sort by reliability and date (newest first)
-3. Fetch matching entries and return ranked results
-
-**Regeneration procedure:**
-- Scan all markdown files in the KB
-- Extract frontmatter and first content line
-- Sort entries by domain, then by filename
-- Rebuild the index table
-- Commit and publish index update
 
 ---
 

--- a/skills/ke/references/index-template.md
+++ b/skills/ke/references/index-template.md
@@ -26,9 +26,7 @@ This is a template for generating the knowledge base index. The values below are
 
 # Knowledge Base Index
 
-**Last updated:** 2026-04-25 (example — replace with current date)  
-**Total entries:** 42 (example — replace with actual count)  
-**Domains:** 6 (example — list actual domains: architecture, database, api-design, security, infrastructure, patterns)
+> Last updated: {YYYY-MM-DD} | Total entries: {N} | Domains: {domain-a, domain-b, ...}
 
 ---
 

--- a/skills/ke/references/index-template.md
+++ b/skills/ke/references/index-template.md
@@ -1,0 +1,49 @@
+# Knowledge Base Index
+
+**Last updated:** 2026-04-25  
+**Total entries:** 42  
+**Domains:** 6 (architecture, database, api-design, security, infrastructure, patterns)
+
+---
+
+## Architecture
+
+| Entry | Type | Date | Reliability | Tags | Summary |
+|-------|------|------|-------------|------|---------|
+| [Hexagonal Pattern Principles](./architecture/hexagonal-pattern-principles.md) | decision | 2026-04-20 | high | architecture, design-pattern, layering | Core architectural pattern emphasizing domain independence from frameworks |
+| [Service Boundary Rules](./architecture/service-boundary-rules.md) | constraint | 2026-04-18 | high | architecture, microservices | Defines when to split services and how to model dependencies |
+| [Event-Driven Communication](./architecture/event-driven-communication.md) | procedure | 2026-04-15 | medium | architecture, messaging, async | Step-by-step guide for implementing event sourcing patterns |
+
+## Database
+
+| Entry | Type | Date | Reliability | Tags | Summary |
+|-------|------|------|-------------|------|---------|
+| [Transaction Isolation Levels](./database/transaction-isolation-levels.md) | fact | 2026-04-22 | high | database, transactions, concurrency | Overview of ACID properties and isolation level tradeoffs |
+| [Index Strategy](./database/index-strategy.md) | decision | 2026-04-10 | high | database, performance, indexing | Rules for when and how to index columns |
+
+---
+
+## Index Management
+
+**Updated atomically on every ingest:** When new knowledge entries are added to the knowledge base, the index is regenerated completely. This ensures consistency between the index table and the actual files on disk.
+
+**Used for candidate search on every query:** The index table enables fast filtering by domain, type, date, and reliability before fetching full entry contents. Search logic:
+1. Filter candidates by domain and tags
+2. Sort by reliability and date (newest first)
+3. Fetch matching entries and return ranked results
+
+**Regeneration procedure:**
+- Scan all markdown files in the KB
+- Extract frontmatter and first content line
+- Sort entries by domain, then by filename
+- Rebuild the index table
+- Commit and publish index update
+
+---
+
+## How to Use This Index
+
+1. **Find an entry:** Search by domain name or use the table of contents
+2. **Read an entry:** Click the linked title to open the full markdown file
+3. **Understand reliability:** Check the Reliability column (high = verified, medium = assumed, low = experimental)
+4. **See relationships:** Review the `related` field in each entry's frontmatter to discover connected concepts

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: ke:query
+description: >
+  Direct entry to Knowledge Engine query mode. Answer questions or produce output using stored knowledge.
+  Use when you have a question and want to query the knowledge base directly.
+  Keywords: query, ask, recall, retrieve, answer, knowledge base, what do we know
+allowed-tools: Read, Bash, Grep, Glob
+---
+
+# Knowledge Engine Query Mode (ke:query)
+
+Answer questions or produce output directly by querying a stored knowledge base.
+No mode detection. No ingest. Read-only: this skill never writes files.
+
+---
+
+## Usage
+
+```
+/ke:query "What is the project architecture?"
+/ke:query "Summarize the deployment process as a checklist"
+/ke:query --kb ~/project-kb "How do we handle authentication?"
+```
+
+Optional: `--kb <path>` to override the knowledge base location.
+
+---
+
+## KNOWLEDGE_PATH Resolution
+
+Locate the knowledge base root directory in this order:
+
+1. `--kb <path>` argument
+2. Environment variable `KNOWLEDGE_PATH`
+3. `./knowledge/index.md` in the current working directory
+4. `~/knowledge/index.md`
+5. Not found → inform user: *"No knowledge base found. Use /ke:ingest to store knowledge first. I can answer from general knowledge if needed."*
+
+If the KB path exists but is empty or index.md is missing, proceed to Phase 2 with 0 candidates. Do NOT create or initialize anything.
+
+---
+
+## The Query Flow: 7 Phases
+
+### Phase 1: Problem Definition
+
+Rephrase the question precisely. Identify relevant domains. Determine output format.
+
+**Output**: `[Query: rephrased text] [Domains: X, Y] [Format: prose/list/table/code/analysis/document]`
+
+**Decision**: If output format is ambiguous, ask ONE clarifying question only:
+> "What format works best? e.g., prose summary, comparison table, bullet list, code example, step-by-step instructions"
+
+---
+
+### Phase 2: Candidate Collection
+
+Read `index.md`. Find entries whose domain, tags, or summary match the query. Read each candidate entry file.
+
+**Output**: List of candidates with brief relevance notes:
+```
+domain/slug.md — relevant because: [reason]
+domain/slug.md — relevant because: [reason]
+```
+
+**Decision**: If 0 candidates found, report:
+> "No stored knowledge matches this query. Proceeding with general knowledge only."
+
+---
+
+### Phase 3: Ranking & Selection
+
+Rank candidates by relevance, recency (prefer newer), and reliability (prefer higher). Keep top candidates.
+
+For simple queries with 1–2 matching entries: execute silently, skip to Phase 4.
+
+---
+
+### Phase 4: Context Assembly
+
+Organize selected entries and relevant excerpts into a coherent context block for answering.
+Sequence them logically.
+
+---
+
+### Phase 5: Compression
+
+Summarize tangential context to fit the context budget. Prioritize directly relevant information.
+
+For simple queries: execute silently.
+
+---
+
+### Phase 6: Generation
+
+Generate the answer in the requested output format (determined in Phase 1).
+
+Supported formats (non-exhaustive): prose narrative, bullet list, comparison table, code snippet, structured analysis, full document, step-by-step instructions, numbered summary.
+
+---
+
+### Phase 7: Verification
+
+Check the answer for unsupported claims, internal contradictions, and gaps relative to stored knowledge.
+
+Append a confidence footer:
+```
+[Confidence: H/M/L] — based on N entries. Gaps: {gap description or "none"}
+```
+
+**Confidence levels**:
+- **H (High)**: 3+ consistent recent entries; answer is well-grounded
+- **M (Medium)**: 1–2 entries or dated entries; gaps noted, answer is reasonable
+- **L (Low)**: 0 relevant entries or contradictory entries; answer relies on general knowledge — always warn
+
+Example footer:
+```
+[Confidence: M] — based on 1 entry (older). Gaps: no recent updates on authentication changes
+```
+
+---
+
+## Behavior Rules
+
+1. **Read-only always**: Never write files, modify index.md, or create directories.
+2. **Graceful degradation**: Missing or empty KB → answer from general knowledge, noted in confidence footer.
+3. **Phase visibility**: Show phase transitions only for complex multi-domain queries. Simple queries execute Phases 1–5 silently.
+4. **No gates**: Flow without interruption except single-question decision points.
+5. **Always append footer**: Query mode always includes a confidence footer. If Low, add: *"Consider ingesting more information on this topic before relying on this answer."*
+
+---

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -70,9 +70,11 @@ domain/slug.md — relevant because: [reason]
 
 ### Phase 3: Ranking & Selection
 
+**Simple query**: Single-domain query returning ≤2 matching candidates. **Complex query**: Multi-domain OR >2 candidates.
+
 Rank candidates by relevance, recency (prefer newer), and reliability (prefer higher). Keep top candidates.
 
-For simple queries (see simple query definition) with 1–2 matching entries: execute silently, skip to Phase 4.
+For simple queries with 1–2 matching entries: execute silently, skip to Phase 4.
 
 ---
 
@@ -87,7 +89,7 @@ Sequence them logically.
 
 Summarize tangential context to fit the context budget. Prioritize directly relevant information.
 
-For simple queries (see simple query definition): execute silently.
+For simple queries: execute silently.
 
 ---
 
@@ -132,7 +134,5 @@ Consider ingesting more recent information to improve accuracy.
 3. **Phase visibility**: Show phase transitions only for complex multi-domain queries. Simple queries execute Phases 1–5 silently.
 4. **No gates**: Flow without interruption except single-question decision points.
 5. **Always append footer**: Query mode always includes a confidence footer. If Low, add the standard warning (see Phase 7 Verification).
-
-**Simple query definition**: Single-domain query returning ≤2 matching candidates. **Complex query**: Multi-domain OR >2 candidates.
 
 ---

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -72,7 +72,7 @@ domain/slug.md — relevant because: [reason]
 
 Rank candidates by relevance, recency (prefer newer), and reliability (prefer higher). Keep top candidates.
 
-For simple queries with 1–2 matching entries: execute silently, skip to Phase 4.
+For simple queries (see simple query definition) with 1–2 matching entries: execute silently, skip to Phase 4.
 
 ---
 
@@ -87,7 +87,7 @@ Sequence them logically.
 
 Summarize tangential context to fit the context budget. Prioritize directly relevant information.
 
-For simple queries: execute silently.
+For simple queries (see simple query definition): execute silently.
 
 ---
 
@@ -103,19 +103,24 @@ Supported formats (non-exhaustive): prose narrative, bullet list, comparison tab
 
 Check the answer for unsupported claims, internal contradictions, and gaps relative to stored knowledge.
 
-Append a confidence footer:
-```
-[Confidence: H/M/L] — based on N entries. Gaps: {gap description or "none"}
-```
+**Confidence levels and footer format**:
 
-**Confidence levels**:
 - **H (High)**: 3+ consistent recent entries; answer is well-grounded
-- **M (Medium)**: 1–2 entries or dated entries; gaps noted, answer is reasonable
-- **L (Low)**: 0 relevant entries or contradictory entries; answer relies on general knowledge — always warn
+  - Append footer only: `[Confidence: H] — based on N entries. Gaps: {gap description or "none"}`
 
-Example footer:
+- **M (Medium)**: 1–2 entries or dated entries; gaps noted, answer is reasonable
+  - Append footer: `[Confidence: M] — based on N entries. Gaps: {gap description or "none"}`
+  - Add note: *"Consider ingesting more recent information to improve accuracy."*
+
+- **L (Low)**: 0 relevant entries or contradictory entries; answer relies on general knowledge — always warn
+  - Append footer: `[Confidence: L] — based on N entries. Gaps: {gap description or "none"}`
+  - Add warning: *"⚠ Answer relies primarily on general knowledge, not stored entries. Consider ingesting relevant knowledge before relying on this answer."*
+
+Example footer (M confidence):
 ```
 [Confidence: M] — based on 1 entry (older). Gaps: no recent updates on authentication changes
+
+Consider ingesting more recent information to improve accuracy.
 ```
 
 ---
@@ -126,6 +131,8 @@ Example footer:
 2. **Graceful degradation**: Missing or empty KB → answer from general knowledge, noted in confidence footer.
 3. **Phase visibility**: Show phase transitions only for complex multi-domain queries. Simple queries execute Phases 1–5 silently.
 4. **No gates**: Flow without interruption except single-question decision points.
-5. **Always append footer**: Query mode always includes a confidence footer. If Low, add: *"Consider ingesting more information on this topic before relying on this answer."*
+5. **Always append footer**: Query mode always includes a confidence footer. If Low, add the standard warning (see Phase 7 Verification).
+
+**Simple query definition**: Single-domain query returning ≤2 matching candidates. **Complex query**: Multi-domain OR >2 candidates.
 
 ---


### PR DESCRIPTION
## Summary

- `/ke` 범용 7-phase 지식 엔진 추가 — 도메인 무관, 소프트웨어 개발에 종속되지 않음
- Ingest/Query 두 모드가 동일한 7-phase 엔진 공유 (자동 모드 감지)
- `/ke:ingest`, `/ke:query` 직접 진입 서브스킬 추가
- 기존 `context-engineering` 스킬 트리는 그대로 유지
- plugin.json v2.0.0, CLAUDE.md ke 설계 불변 규칙, README.md ke 섹션 갱신

## New Files

- `skills/ke/SKILL.md` — 메인 7-phase 엔진
- `skills/ke/references/entry-template.md` — 지식 엔트리 포맷 템플릿
- `skills/ke/references/index-template.md` — index.md 포맷 템플릿
- `skills/ingest/SKILL.md` — Ingest 직접 진입 서브스킬
- `skills/query/SKILL.md` — Query 직접 진입 서브스킬 (read-only)

## Test Plan

- [ ] `/ke` 호출 후 Ingest/Query 자동 감지 동작 확인
- [ ] `/ke:ingest` 로 단순 사실 저장, `~/knowledge/` 파일 생성 확인
- [ ] `/ke:query` 로 저장된 지식 기반 답변 + 신뢰도 표시 확인
- [ ] 빈 KB에서 `/ke:query` 호출 시 안내 메시지 확인