### PR TITLE
docs: CLAUDE.md 헤더 수정 및 영문화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,49 +1,49 @@
-# CLAUDE.md
+# Context Engineering
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> 7-Phase Context Engineering 파이프라인 — AI에게 보낼 컨텍스트를 잘 만드는 Claude Code 플러그인
+> A Claude Code plugin for systematically building context to send to AI — 7-Phase pipeline.
 
 ## Project Nature
 
-소스 코드 없음. **순수 마크다운** Claude Code 플러그인:
-- `.claude-plugin/plugin.json` — 플러그인 메타데이터 (v3.1.0)
-- `skills/context-engineering/SKILL.md` — 오케스트레이터 (전체 7-Phase 파이프라인)
-- `skills/context-engineering/references/` — 10개 템플릿 및 참조 문서
-- `skills/gather/SKILL.md` — Phase 1-3 (문제 정의 → 수집 → 선택)
-- `skills/build/SKILL.md` — Phase 4-5 (구조화 → 압축)
-- `skills/compose/SKILL.md` — Phase 6 (실행 지시 생성)
-- `skills/verify/SKILL.md` — Phase 7 (최종 검증)
+No source code. **Pure markdown** Claude Code plugin:
+- `.claude-plugin/plugin.json` — Plugin metadata (v3.1.0)
+- `skills/context-engineering/SKILL.md` — Orchestrator (full 7-Phase pipeline)
+- `skills/context-engineering/references/` — 10 templates and reference documents
+- `skills/gather/SKILL.md` — Phase 1-3 (problem definition → collection → selection)
+- `skills/build/SKILL.md` — Phase 4-5 (structuring → compression)
+- `skills/compose/SKILL.md` — Phase 6 (execution instruction generation)
+- `skills/verify/SKILL.md` — Phase 7 (final verification)
 
 ## Pipeline
 
 ```
 Phase 1 →[G1]→ Phase 2 →[G2]→ Phase 3 →[G3]→
-Phase 4 →[G4]→ Phase 5 →[G5]→ Phase 6 →[G6]→ [출력]
-                                                  ↓ (G6 실패)
+Phase 4 →[G4]→ Phase 5 →[G5]→ Phase 6 →[G6]→ [output]
+                                                  ↓ (G6 fail)
                                                 Phase 7
 ```
 
-| 서브 스킬 | Phase | 역할 |
-|----------|-------|------|
-| `gather` | 1-3 | 문제 정의 → 후보 수집 → 선택 |
-| `build` | 4-5 | 구조화 → 압축 |
-| `compose` | 6 | 실행 지시 생성 |
-| `verify` | 7 | 최종 검증 |
+| Sub-skill | Phase | Role |
+|-----------|-------|------|
+| `gather` | 1-3 | Problem definition → candidate collection → selection |
+| `build` | 4-5 | Structuring → compression |
+| `compose` | 6 | Execution instruction generation |
+| `verify` | 7 | Final verification |
 
-Phase 6은 Phase 1 success criteria 신호에 따라 출력 형식을 자동 결정:
-- **Format A**: 실행 지시 (Role + Task + Constraints + Output Format)
-- **Format B**: KB 엔트리 (frontmatter + Key Facts/Constraints/Decisions/Notes)
-- **Format C**: 프로젝트 산출물 (CLAUDE.md + spec.md + implementation plan)
+Phase 6 automatically determines output format based on Phase 1 success criteria signal:
+- **Format A**: Execution instruction (Role + Task + Constraints + Output Format)
+- **Format B**: KB entry (frontmatter + Key Facts/Constraints/Decisions/Notes)
+- **Format C**: Project artifacts (CLAUDE.md + spec.md + implementation plan)
 
 ## Skill Modification Guidelines
 
-1. **Phase 일관성**: gather → build → compose → verify 흐름 유지
-2. **템플릿 동기화**: `references/` 파일 10개와 SKILL.md 인라인 구조를 항상 일치시킬 것
-3. **게이트 형식**: `"Phase N 결과: {요약}\n 미충족 항목: {내용}\n 수정하거나 승인 후 진행해주세요."` 준수
-4. **게이트 동작**: 기준 명확히 충족 → 자동 통과, 모호한 경우 → 사용자 확인 요청
-5. **Compaction Survival**: 각 SKILL.md의 핵심 행동 계약을 **첫 5,000 토큰** 내에 배치. 보조 정보는 그 뒤에 둘 것 — 컨텍스트 압축 시 뒷부분이 잘림
+1. **Phase consistency**: Maintain the gather → build → compose → verify flow
+2. **Template sync**: Always keep `references/` files and SKILL.md inline structures in sync
+3. **Gate format**: Follow `"Phase N result: {summary}\n Unmet items: {content}\n Please revise or approve to continue."` format
+4. **Gate behavior**: Clearly met criteria → auto-pass, ambiguous → request user confirmation
+5. **Compaction Survival**: Place each SKILL.md's core behavioral contract within the **first 5,000 tokens**. Put supplementary information after — it may be truncated during context compaction
 
 ## Verification
 
-스킬 수정 후 실제 프로젝트에서 `/context-engineering @<path>` 실행하여 Phase 1 질의가 올바르게 시작되는지 확인.
+After modifying a skill, run `/context-engineering @<path>` in a real project to confirm Phase 1 queries start correctly.


### PR DESCRIPTION
## Summary

- 헤더 `# CLAUDE.md` → `# Context Engineering` (글로벌 규칙: 파일명 헤더 금지)
- 본문 전체 영문화 (README.md와 언어 통일)

Closes #118